### PR TITLE
NAS-2290 : Generate revisit records

### DIFF
--- a/harvester/heritrix3/heritrix3-controller/src/main/java/dk/netarkivet/harvester/heritrix3/HarvestDocumentation.java
+++ b/harvester/heritrix3/heritrix3-controller/src/main/java/dk/netarkivet/harvester/heritrix3/HarvestDocumentation.java
@@ -110,7 +110,7 @@ public class HarvestDocumentation {
                 infoPayload.addLabelValue("ip", SystemUtils.getLocalIP());
                 infoPayload.addLabelValue("hostname", SystemUtils.getLocalHostName());
                 infoPayload.addLabelValue("conformsTo",
-                        "http://bibnum.bnf.fr/WARC/WARC_ISO_28500_version1_latestdraft.pdf");
+                        "http://bibnum.bnf.fr/WARC/WARC_ISO_28500_version1-1_latestdraft.pdf");
 
                 PersistentJobData psj = new PersistentJobData(crawlDir);
                 infoPayload.addLabelValue("isPartOf", "" + psj.getJobID());

--- a/harvester/heritrix3/heritrix3-controller/src/main/java/dk/netarkivet/harvester/tools/CreateCDXMetadataFile.java
+++ b/harvester/heritrix3/heritrix3-controller/src/main/java/dk/netarkivet/harvester/tools/CreateCDXMetadataFile.java
@@ -307,7 +307,7 @@ public class CreateCDXMetadataFile extends ToolRunnerBase {
             infoPayload.addLabelValue("ip", SystemUtils.getLocalIP());
             infoPayload.addLabelValue("hostname", SystemUtils.getLocalHostName());
             infoPayload
-                    .addLabelValue("conformsTo", "http://bibnum.bnf.fr/WARC/WARC_ISO_28500_version1_latestdraft.pdf");
+                    .addLabelValue("conformsTo", "http://bibnum.bnf.fr/WARC/WARC_ISO_28500_version1-1_latestdraft.pdf");
             infoPayload.addLabelValue("isPartOf", "" + jobID);
             writer.insertInfoRecord(infoPayload);
         }

--- a/harvester/heritrix3/heritrix3-extensions/src/main/java/dk/netarkivet/harvester/harvesting/NasWARCProcessor.java
+++ b/harvester/heritrix3/heritrix3-extensions/src/main/java/dk/netarkivet/harvester/harvesting/NasWARCProcessor.java
@@ -84,8 +84,8 @@ public class NasWARCProcessor extends WARCWriterProcessor {
         // conforms to ISO 28500:2009 as of May 2009
         // as described at http://bibnum.bnf.fr/WARC/ 
         // latest draft as of November 2008
-        record.addLabelValue("format","WARC File Format 1.0"); 
-        record.addLabelValue("conformsTo","http://bibnum.bnf.fr/WARC/WARC_ISO_28500_version1_latestdraft.pdf");
+        record.addLabelValue("format","WARC File Format 1.1"); 
+        record.addLabelValue("conformsTo","http://bibnum.bnf.fr/WARC/WARC_ISO_28500_version1-1_latestdraft.pdf");
         
         // Get other values from metadata provider
 


### PR DESCRIPTION
Changing warc version in warcinfo record (conformsTo)
(But the file http://bibnum.bnf.fr/WARC/WARC_ISO_28500_version1-1_latestdraft.pdf doesn't exist yet)

To make the general processing of the WARC file easier from a preservation perspective, all the records should probably be 1.1 from now on, but this version is hard-coded in webarchive-commons library :
```
package org.archive.format.warc;
public interface WARCConstants extends ArchiveFileConstants {
    /**
     * Hard-coded version for WARC files made with this code.
     * conforms to ISO 28500:2009 as of May 2009
     */
	public static final String WARC_VERSION = "1.0";
```

I don't know what is the easiest way to change this version.
