### PR TITLE
Progress reporting in CDXMapper

### DIFF
--- a/wayback/wayback-indexer/src/main/java/dk/netarkivet/wayback/hadoop/CDXMapper.java
+++ b/wayback/wayback-indexer/src/main/java/dk/netarkivet/wayback/hadoop/CDXMapper.java
@@ -63,12 +63,12 @@ public class CDXMapper extends Mapper<LongWritable, Text, NullWritable, Text> {
                 cdxIndexes = new ArrayList<>();
             } else {
                 LocalFileSystem localFileSystem = ((LocalFileSystem) fileSystem);
-                cdxIndexes = indexer.indexFile(localFileSystem.pathToFile(path));
+                cdxIndexes = indexer.indexFile(localFileSystem.pathToFile(path), context);
             }
         } else {
             log.info("CDX-indexing archive file '{}'", path);
             try (InputStream in = new BufferedInputStream(path.getFileSystem(context.getConfiguration()).open(path))) {
-                cdxIndexes = cdxIndexer.index(in, archiveFilePath.toString());
+                cdxIndexes = cdxIndexer.index(in, archiveFilePath.toString(), context);
             }
         }
         for (String cdxIndex : cdxIndexes) {

--- a/wayback/wayback-indexer/src/main/java/dk/netarkivet/wayback/hadoop/DedupIndexer.java
+++ b/wayback/wayback-indexer/src/main/java/dk/netarkivet/wayback/hadoop/DedupIndexer.java
@@ -6,15 +6,18 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.hadoop.util.Progressable;
+
 import dk.netarkivet.common.utils.batch.FileBatchJob;
 import dk.netarkivet.wayback.batch.DeduplicationCDXExtractionBatchJob;
 
 public class DedupIndexer implements Indexer {
 
-    @Override public List<String> indexFile(File file) throws IOException {
+    @Override public List<String> indexFile(File file, Progressable progressable) throws IOException {
         FileBatchJob fileBatchJob = new DeduplicationCDXExtractionBatchJob();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         fileBatchJob.initialize(baos);
+        //TODO this could fail on timeout as the progressable is not updated
         fileBatchJob.processFile(file, baos);
         fileBatchJob.finish(baos);
         baos.flush();

--- a/wayback/wayback-indexer/src/main/java/dk/netarkivet/wayback/hadoop/Indexer.java
+++ b/wayback/wayback-indexer/src/main/java/dk/netarkivet/wayback/hadoop/Indexer.java
@@ -4,8 +4,10 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
+import org.apache.hadoop.util.Progressable;
+
 public interface Indexer {
 
-    List<String> indexFile(File file) throws IOException;
+    List<String> indexFile(File file, Progressable progressable) throws IOException;
 
 }


### PR DESCRIPTION
The error

```
2021-09-14 10:00:12,190 INFO [communication thread] org.apache.hadoop.mapred.TaskAttemptListenerImpl: Progress of TaskAttempt attempt_1623324923294_7063_m_000000_0 is : 1.0

2021-09-14 10:05:35,514 INFO [AsyncDispatcher event handler] org.apache.hadoop.mapreduce.v2.app.job.impl.TaskAttemptImpl: Diagnostics report from attempt_1623324923294_7063_m_000000_0: AttemptID:attempt_1623324923294_7063_m_000000_0 Timed out after 300 secs
```

Seems to be caused by the map job taking to long without reporting anything. Hadoop then thinks the thread is stuck and fails the task. 
So I springled some `context.progress()` in the loops to make sure that hadoop never looses contact with the thread