### PR TITLE
dedupIndexer can now send progress info to hadoop and thus hopefully prevent timeouts

### DIFF
--- a/wayback/wayback-indexer/src/main/java/dk/netarkivet/wayback/hadoop/ProgressableOutputStream.java
+++ b/wayback/wayback-indexer/src/main/java/dk/netarkivet/wayback/hadoop/ProgressableOutputStream.java
@@ -1,0 +1,48 @@
+package dk.netarkivet.wayback.hadoop;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.apache.hadoop.util.Progressable;
+
+/**
+ * An OutputStream Wrapper that calls Progressable.progress() for each operation
+ * This is a hack, in order for us to feed progressable into the BatchJob interface
+ * @see DedupIndexer
+ * @see dk.netarkivet.wayback.batch.DeduplicationCDXExtractionBatchJob
+ *
+ */
+public class ProgressableOutputStream extends OutputStream {
+    private final OutputStream os;
+    private final Progressable progressable;
+
+    public ProgressableOutputStream(OutputStream os, Progressable progressable) {
+        this.os = os;
+        this.progressable = progressable;
+    }
+
+    @Override public void write(int b) throws IOException {
+        os.write(b);
+        progressable.progress();
+    }
+
+    @Override public void write(byte[] b) throws IOException {
+        os.write(b);
+        progressable.progress();
+    }
+
+    @Override public void write(byte[] b, int off, int len) throws IOException {
+        os.write(b, off, len);
+        progressable.progress();
+    }
+
+    @Override public void flush() throws IOException {
+        os.flush();
+        progressable.progress();
+    }
+
+    @Override public void close() throws IOException {
+        os.close();
+        progressable.progress();
+    }
+}


### PR DESCRIPTION
Prevents errors list this

```
2022-01-01 15:53:46,733 INFO [uber-SubtaskRunner] dk.netarkivet.wayback.hadoop.CDXMapper: Dedup-indexing metadata file 'file:/netarkivet/016j/fildir/10089-metadata-1.warc.gz'
2022-01-01 15:53:46,755 INFO [uber-SubtaskRunner] dk.netarkivet.common.utils.archive.ArchiveBatchJob: Processing archive file: 10089-metadata-1.warc.gz
2022-01-01 15:53:52,461 INFO [communication thread] org.apache.hadoop.mapred.TaskAttemptListenerImpl: Progress of TaskAttempt attempt_1623324923294_11038_m_000000_0 is : 1.0
2022-01-01 15:59:15,922 INFO [AsyncDispatcher event handler] org.apache.hadoop.mapreduce.v2.app.job.impl.TaskAttemptImpl: Diagnostics report from attempt_1623324923294_11038_m_000000_0: AttemptID:attempt_1623324923294_11038_m_000000_0 Timed out after 300 secs
```