### PR TITLE
[SECURITY] Fix Temporary File Information Disclosure Vulnerability


### DIFF
--- a/archive/archive-core/src/main/java/dk/netarkivet/archive/arcrepository/distribute/JMSArcRepositoryClient.java
+++ b/archive/archive-core/src/main/java/dk/netarkivet/archive/arcrepository/distribute/JMSArcRepositoryClient.java
@@ -24,6 +24,7 @@ package dk.netarkivet.archive.arcrepository.distribute;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -480,7 +481,7 @@ public class JMSArcRepositoryClient extends Synchronizer implements ArcRepositor
 
         try {
             // retrieve the data from this message and place it in tempDir.
-            File result = File.createTempFile("tmp", "tmp", FileUtils.getTempDir());
+            File result = Files.createTempFile(FileUtils.getTempDir().toPath(), "tmp", "tmp").toFile();
             replyCSMsg.getData(result);
 
             return result;
@@ -530,7 +531,7 @@ public class JMSArcRepositoryClient extends Synchronizer implements ArcRepositor
 
         try {
             // retrieve the data from this message.
-            File result = File.createTempFile("tmp", "tmp", FileUtils.getTempDir());
+            File result = Files.createTempFile(FileUtils.getTempDir().toPath(), "tmp", "tmp").toFile();
             replyCSMsg.getData(result);
 
             return result;

--- a/archive/archive-core/src/main/java/dk/netarkivet/archive/bitarchive/Bitarchive.java
+++ b/archive/archive-core/src/main/java/dk/netarkivet/archive/bitarchive/Bitarchive.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.Date;
 
 import org.archive.io.ArchiveReader;
@@ -193,7 +194,7 @@ public class Bitarchive {
 
         File tmpFile = null;
         try {
-            tmpFile = File.createTempFile("BatchOutput", "", FileUtils.getTempDir());
+            tmpFile = Files.createTempFile(FileUtils.getTempDir().toPath(), "BatchOutput", "").toFile();
             final OutputStream os = new FileOutputStream(tmpFile);
 
             try {

--- a/archive/archive-core/src/main/java/dk/netarkivet/archive/bitarchive/BitarchiveMonitor.java
+++ b/archive/archive-core/src/main/java/dk/netarkivet/archive/bitarchive/BitarchiveMonitor.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -307,8 +308,7 @@ public class BitarchiveMonitor extends Observable implements CleanupIF {
             batchTimer.schedule(batchTimeoutTask, batchTimeout);
             this.noOfFilesProcessed = 0;
             try {
-                this.batchResultFile = File.createTempFile(bitarchiveBatchID, "batch_aggregation",
-                        FileUtils.getTempDir());
+                this.batchResultFile = Files.createTempFile(FileUtils.getTempDir().toPath(), bitarchiveBatchID, "batch_aggregation").toFile();
             } catch (IOException e) {
                 log.warn("Unable to create file for batch output");
                 throw new IOFailure("Unable to create file for batch output", e);

--- a/archive/archive-core/src/main/java/dk/netarkivet/archive/bitarchive/distribute/BitarchiveMonitorServer.java
+++ b/archive/archive-core/src/main/java/dk/netarkivet/archive/bitarchive/distribute/BitarchiveMonitorServer.java
@@ -25,6 +25,7 @@ package dk.netarkivet.archive.bitarchive.distribute;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -476,7 +477,7 @@ public class BitarchiveMonitorServer extends ArchiveMessageHandler implements Ob
         RemoteFile resultsFile = null;
         try {
             // Post process the file.
-            File postFile = File.createTempFile("post", "batch", FileUtils.getTempDir());
+            File postFile = Files.createTempFile(FileUtils.getTempDir().toPath(), "post", "batch").toFile();
             try {
                 // retrieve the batchjob
                 FileBatchJob bj = batchjobs.remove(bjs.originalRequestID);

--- a/archive/archive-core/src/main/java/dk/netarkivet/archive/checksum/DatabaseChecksumArchive.java
+++ b/archive/archive-core/src/main/java/dk/netarkivet/archive/checksum/DatabaseChecksumArchive.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Date;
 
 import org.apache.commons.io.IOUtils;
@@ -248,7 +249,7 @@ public class DatabaseChecksumArchive implements ChecksumArchive {
         File removedEntryFile;
         try {
             // Initialise file and writer.
-            removedEntryFile = File.createTempFile(filename, "tmp", FileUtils.getTempDir());
+            removedEntryFile = Files.createTempFile(FileUtils.getTempDir().toPath(), filename, "tmp").toFile();
             FileWriter fw = new FileWriter(removedEntryFile);
 
             // Write the bad entry.
@@ -417,7 +418,7 @@ public class DatabaseChecksumArchive implements ChecksumArchive {
     public File getArchiveAsFile() {
         File tempFile = null;
         try {
-            tempFile = File.createTempFile("allFilenamesAndChecksums", "tmp", FileUtils.getTempDir());
+            tempFile = Files.createTempFile(FileUtils.getTempDir().toPath(), "allFilenamesAndChecksums", "tmp").toFile();
             log.debug("Creating temporary file for checksums: " + tempFile.getAbsolutePath());
             dumpDatabaseToFile(tempFile, false);
             log.debug("Dumped checksums to temporary file: " + tempFile.getAbsolutePath());
@@ -479,7 +480,7 @@ public class DatabaseChecksumArchive implements ChecksumArchive {
     public File getAllFilenames() {
         File tempFile = null;
         try {
-            tempFile = File.createTempFile("allFilenames", "tmp", FileUtils.getTempDir());
+            tempFile = Files.createTempFile(FileUtils.getTempDir().toPath(), "allFilenames", "tmp").toFile();
         } catch (IOException e) {
             throw new IOFailure(e.toString());
         }

--- a/archive/archive-core/src/main/java/dk/netarkivet/archive/checksum/FileChecksumArchive.java
+++ b/archive/archive-core/src/main/java/dk/netarkivet/archive/checksum/FileChecksumArchive.java
@@ -28,6 +28,7 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -729,7 +730,7 @@ public final class FileChecksumArchive implements ChecksumArchive {
         File removedEntryFile;
         try {
             // Initialise file and writer.
-            removedEntryFile = File.createTempFile(filename, "tmp", FileUtils.getTempDir());
+            removedEntryFile = Files.createTempFile(FileUtils.getTempDir().toPath(), filename, "tmp").toFile();
             FileWriter fw = new FileWriter(removedEntryFile);
 
             // Write the bad entry.
@@ -759,7 +760,7 @@ public final class FileChecksumArchive implements ChecksumArchive {
 
         try {
             // create new temporary file of the archive.
-            File tempFile = File.createTempFile("tmp", "tmp", FileUtils.getTempDir());
+            File tempFile = Files.createTempFile(FileUtils.getTempDir().toPath(), "tmp", "tmp").toFile();
             synchronized (this) {
                 FileUtils.copyFile(checksumFile, tempFile);
             }
@@ -783,7 +784,7 @@ public final class FileChecksumArchive implements ChecksumArchive {
         synchronizeMemoryWithFile();
 
         try {
-            File tempFile = File.createTempFile("tmp", "tmp", FileUtils.getTempDir());
+            File tempFile = Files.createTempFile(FileUtils.getTempDir().toPath(), "tmp", "tmp").toFile();
             FileWriter fw = new FileWriter(tempFile);
 
             try {

--- a/archive/archive-core/src/main/java/dk/netarkivet/archive/checksum/distribute/ChecksumFileServer.java
+++ b/archive/archive-core/src/main/java/dk/netarkivet/archive/checksum/distribute/ChecksumFileServer.java
@@ -23,6 +23,7 @@
 package dk.netarkivet.archive.checksum.distribute;
 
 import java.io.File;
+import java.nio.file.Files;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -248,7 +249,7 @@ public class ChecksumFileServer extends ChecksumArchiveServer {
             }
 
             // retrieve the data as a file.
-            correctFile = File.createTempFile("correct", filename, FileUtils.getTempDir());
+            correctFile = Files.createTempFile(FileUtils.getTempDir().toPath(), "correct", filename).toFile();
             msg.getData(correctFile);
 
             // Log and notify

--- a/archive/archive-core/src/test/java/dk/netarkivet/archive/bitarchive/distribute/BitarchiveMonitorServerTester.java
+++ b/archive/archive-core/src/test/java/dk/netarkivet/archive/bitarchive/distribute/BitarchiveMonitorServerTester.java
@@ -35,6 +35,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -745,7 +746,7 @@ Caused by: dk.netarkivet.common.exceptions.ArgumentNotValid: File '/home/svc/dev
                 msg instanceof GetAllChecksumsMessage);
 
         GetAllChecksumsMessage returnMsg = (GetAllChecksumsMessage) msg;
-        File tempFile = File.createTempFile("checksum", "all", TestInfo.BAMON_WORKING);
+        File tempFile = Files.createTempFile(TestInfo.BAMON_WORKING.toPath(), "checksum", "all").toFile();
         returnMsg.getData(tempFile);
 
         List<String> batchOutput = FileUtils.readListFromFile(tempFile);
@@ -811,7 +812,7 @@ Caused by: dk.netarkivet.common.exceptions.ArgumentNotValid: File '/home/svc/dev
                 msg instanceof GetAllFilenamesMessage);
 
         GetAllFilenamesMessage returnMsg = (GetAllFilenamesMessage) msg;
-        File tempFile = File.createTempFile("filenames", "all", TestInfo.BAMON_WORKING);
+        File tempFile = Files.createTempFile(TestInfo.BAMON_WORKING.toPath(), "filenames", "all").toFile();
         returnMsg.getData(tempFile);
 
         List<String> batchOutput = FileUtils.readListFromFile(tempFile);

--- a/archive/archive-test/src/test/java/dk/netarkivet/archive/arcrepository/TrivialArcRepositoryClientTester.java
+++ b/archive/archive-test/src/test/java/dk/netarkivet/archive/arcrepository/TrivialArcRepositoryClientTester.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertFalse;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.nio.file.Files;
 
 import org.junit.After;
 import org.junit.Before;
@@ -89,7 +90,7 @@ public class TrivialArcRepositoryClientTester {
         status.getResultFile().appendTo(out);
         assertEquals("Should list the one file",
         		TestInfo.DISTRIBUTE_ARCREPOSITORY_SAMPLE_FILE.getName() + "\n", out.toString());
-        File f = File.createTempFile("foo", "bar", FileUtils.getTempDir());
+        File f = Files.createTempFile(FileUtils.getTempDir().toPath(), "foo", "bar").toFile();
         arcrep.getFile(TestInfo.DISTRIBUTE_ARCREPOSITORY_SAMPLE_FILE.getName(),
                 Replica.getReplicaFromId("TWO"), f);
         assertEquals("Should have expected contents back",

--- a/archive/archive-test/src/test/java/dk/netarkivet/archive/arcrepository/bitpreservation/DatabaseBasedActiveBitPreservationTester.java
+++ b/archive/archive-test/src/test/java/dk/netarkivet/archive/arcrepository/bitpreservation/DatabaseBasedActiveBitPreservationTester.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.sql.Connection;
 import java.sql.Date;
 import java.sql.PreparedStatement;
@@ -240,7 +241,7 @@ public class DatabaseBasedActiveBitPreservationTester {
         List<String> filelist = new ArrayList<String>();
         filelist.add("integrity1.ARC");
         filelist.add("integrity7.ARC");
-        File tmpFile = File.createTempFile("file", "txt");
+        File tmpFile = Files.createTempFile("file", "txt").toFile();
         FileUtils.writeCollectionToFile(tmpFile, filelist);
 
         ReplicaCacheDatabase.getInstance().addFileListInformation(tmpFile, REPLICA_THREE);
@@ -291,7 +292,7 @@ public class DatabaseBasedActiveBitPreservationTester {
         checksumlist.add("1.arc##1234");
         checksumlist.add("2.arc##2345");
 
-        File checksumFile = File.createTempFile("file", "txt");
+        File checksumFile = Files.createTempFile("file", "txt").toFile();
         FileUtils.writeCollectionToFile(checksumFile, checksumlist);
 
         cache.addChecksumInformation(checksumFile, REPLICA_TWO);
@@ -307,7 +308,7 @@ public class DatabaseBasedActiveBitPreservationTester {
 
         checksumlist.clear();
         checksumlist.add("1.arc##1234");
-        checksumFile = File.createTempFile("file", "txt");
+        checksumFile = Files.createTempFile("file", "txt").toFile();
         FileUtils.writeCollectionToFile(checksumFile, checksumlist);
         cache.addChecksumInformation(checksumFile, REPLICA_TWO);
         FileUtils.remove(checksumFile);
@@ -473,7 +474,7 @@ public class DatabaseBasedActiveBitPreservationTester {
                 return overrideBatch;
             }
             try {
-                File output = File.createTempFile("Batch", ".dat", TestInfo.WORKING_DIR);
+                File output = Files.createTempFile(TestInfo.WORKING_DIR.toPath(), "Batch", ".dat").toFile();
                 File[] in_files = TestInfo.GOOD_ARCHIVE_FILE_DIR.listFiles();
                 FileOutputStream os = new FileOutputStream(output);
                 new BatchLocalFiles(in_files).run(job, os);
@@ -511,7 +512,7 @@ public class DatabaseBasedActiveBitPreservationTester {
             }
             File output = null;
             try {
-                output = File.createTempFile(fileName, ".removed", TestInfo.WORKING_DIR);
+                output = Files.createTempFile(TestInfo.WORKING_DIR.toPath(), fileName, ".removed").toFile();
             } catch (IOException e) {
                 fail("IO error during test.");
             }
@@ -526,7 +527,7 @@ public class DatabaseBasedActiveBitPreservationTester {
         public File getAllChecksums(String replicaId) {
             try {
                 ChecksumJob job = new ChecksumJob();
-                File output = File.createTempFile("checksum", ".all", TestInfo.WORKING_DIR);
+                File output = Files.createTempFile(TestInfo.WORKING_DIR.toPath(), "checksum", ".all").toFile();
                 File[] in_files = TestInfo.GOOD_ARCHIVE_FILE_DIR.listFiles();
                 FileOutputStream os = new FileOutputStream(output);
                 new BatchLocalFiles(in_files).run(job, os);
@@ -540,7 +541,7 @@ public class DatabaseBasedActiveBitPreservationTester {
         @Override
         public File getAllFilenames(String replicaId) {
             try {
-                File result = File.createTempFile("temp", "temp");
+                File result = Files.createTempFile("temp", "temp").toFile();
                 FileWriter fw = new FileWriter(result);
                 File[] files = TestInfo.GOOD_ARCHIVE_FILE_DIR.listFiles();
 

--- a/archive/archive-test/src/test/java/dk/netarkivet/archive/arcrepository/bitpreservation/FileBasedActiveBitPreservationTester.java
+++ b/archive/archive-test/src/test/java/dk/netarkivet/archive/arcrepository/bitpreservation/FileBasedActiveBitPreservationTester.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -557,7 +558,7 @@ public class FileBasedActiveBitPreservationTester {
          */
         public BatchStatus batch(FileBatchJob job, String locationName, RemoteFile file) throws IOException {
             BatchStatus lbs = null;
-            File tmpfile = File.createTempFile("DummyBatch", "");
+            File tmpfile = Files.createTempFile("DummyBatch", "").toFile();
             OutputStream os = new FileOutputStream(tmpfile);
             // The file name
             File bitarchive_dir = new File(TestInfo.WORKING_DIR, locationName);
@@ -640,7 +641,7 @@ public class FileBasedActiveBitPreservationTester {
                 return overrideBatch;
             }
             try {
-                File output = File.createTempFile("Batch", ".dat", TestInfo.WORKING_DIR);
+                File output = Files.createTempFile(TestInfo.WORKING_DIR.toPath(), "Batch", ".dat").toFile();
                 File[] in_files = TestInfo.GOOD_ARCHIVE_FILE_DIR.listFiles();
                 FileOutputStream os = new FileOutputStream(output);
                 new BatchLocalFiles(in_files).run(job, os);
@@ -673,7 +674,7 @@ public class FileBasedActiveBitPreservationTester {
             }
             File output = null;
             try {
-                output = File.createTempFile(fileName, ".removed", TestInfo.WORKING_DIR);
+                output = Files.createTempFile(TestInfo.WORKING_DIR.toPath(), fileName, ".removed").toFile();
             } catch (IOException e) {
                 fail("IO error during test.");
             }
@@ -687,7 +688,7 @@ public class FileBasedActiveBitPreservationTester {
         public File getAllChecksums(String replicaId) {
             try {
                 BatchStatus bs = batch(new ChecksumJob(), replicaId);
-                File result = File.createTempFile("all", ".checksum", TestInfo.WORKING_DIR);
+                File result = Files.createTempFile(TestInfo.WORKING_DIR.toPath(), "all", ".checksum").toFile();
                 bs.copyResults(result);
                 return result;
             } catch (IOException e) {
@@ -700,7 +701,7 @@ public class FileBasedActiveBitPreservationTester {
         public File getAllFilenames(String replicaId) {
             try {
                 BatchStatus bs = batch(new FileListJob(), replicaId);
-                File result = File.createTempFile("all", ".filename", TestInfo.WORKING_DIR);
+                File result = Files.createTempFile(TestInfo.WORKING_DIR.toPath(), "all", ".filename").toFile();
                 bs.copyResults(result);
                 return result;
             } catch (IOException e) {

--- a/archive/archive-test/src/test/java/dk/netarkivet/archive/arcrepositoryadmin/AdminDataTester.java
+++ b/archive/archive-test/src/test/java/dk/netarkivet/archive/arcrepositoryadmin/AdminDataTester.java
@@ -32,6 +32,7 @@ import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
@@ -117,7 +118,7 @@ public class AdminDataTester {
         LogbackRecorder lr = LogbackRecorder.startRecorder();
         ad = UpdateableAdminData.getUpdateableInstance();
         assertFalse("No replyInfo has been set", ad.hasReplyInfo(myFile));
-        StoreMessage myReplyInfo = new StoreMessage(Channels.getError(), File.createTempFile("dummy", "dummy"));
+        StoreMessage myReplyInfo = new StoreMessage(Channels.getError(), Files.createTempFile("dummy", "dummy").toFile());
         // ArchiveStoreState dummyGeneralState = new ArchiveStoreState(BitArchiveStoreState.UPLOAD_STARTED);
         ad.addEntry(myFile, myReplyInfo, "checksum");
         assertTrue("replyInfo has been set", ad.hasReplyInfo(myFile));
@@ -199,7 +200,7 @@ public class AdminDataTester {
     @Test
     public void testPersistence() throws IOException {
         ad = UpdateableAdminData.getInstance();
-        StoreMessage myReplyInfo = new StoreMessage(Channels.getError(), File.createTempFile("dummy", "dummy"));
+        StoreMessage myReplyInfo = new StoreMessage(Channels.getError(), Files.createTempFile("dummy", "dummy").toFile());
         String myChecksum = "Dummychecksum";
         ad.addEntry(myFile, myReplyInfo, myChecksum);
         String myBA = "TestIDofbitarchive";

--- a/archive/archive-test/src/test/java/dk/netarkivet/archive/bitarchive/BitarchiveTesterUpload.java
+++ b/archive/archive-test/src/test/java/dk/netarkivet/archive/bitarchive/BitarchiveTesterUpload.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 
@@ -206,7 +207,7 @@ public class BitarchiveTesterUpload extends BitarchiveTestCase {
         // byte[] contents = new byte[(int) record.getLength()];
         OutputStream os = null;
         try {
-            File tmp = File.createTempFile("uploadtest-", ".tmp");
+            File tmp = Files.createTempFile("uploadtest-", ".tmp").toFile();
             os = new FileOutputStream(tmp);
             record.getData(os);
             assertEquals("Size of record should be equal to 1254", 1254, tmp.length());

--- a/archive/archive-test/src/test/java/dk/netarkivet/archive/checksum/distribute/FileChecksumServerTester.java
+++ b/archive/archive-test/src/test/java/dk/netarkivet/archive/checksum/distribute/FileChecksumServerTester.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.fail;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.List;
 
 import org.junit.After;
@@ -167,7 +168,7 @@ public class FileChecksumServerTester {
         cfs.visit(gacMsg);
         conn.waitForConcurrentTasksToFinish();
         // retrieve the results
-        File tmp = File.createTempFile("tmp2", "tmp", TestInfo.BASE_FILE_DIR);
+        File tmp = Files.createTempFile(TestInfo.BASE_FILE_DIR.toPath(), "tmp2", "tmp").toFile();
         gacMsg.getData(tmp);
 
         String archive = FileUtils.readFile(tmp);
@@ -183,7 +184,7 @@ public class FileChecksumServerTester {
         // file in the list of all the filenames.
         GetChecksumMessage csMsg;
         // Get the filenames
-        File outfile = File.createTempFile("tmp", "tmp");
+        File outfile = Files.createTempFile("tmp", "tmp").toFile();
         afnMsg.getData(outfile);
         List<String> names = FileUtils.readListFromFile(outfile);
 
@@ -299,7 +300,7 @@ public class FileChecksumServerTester {
         cfs.visit(gacMsg);
         conn.waitForConcurrentTasksToFinish();
 
-        File tmp = File.createTempFile("tmp1", "tmp", TestInfo.BASE_FILE_DIR);
+        File tmp = Files.createTempFile(TestInfo.BASE_FILE_DIR.toPath(), "tmp1", "tmp").toFile();
         gacMsg.getData(tmp);
 
         assertNotNull("The file should exist.", tmp.isFile());
@@ -312,7 +313,7 @@ public class FileChecksumServerTester {
         conn.waitForConcurrentTasksToFinish();
 
         // Get the filenames
-        File outfile = File.createTempFile("tmp", "tmp");
+        File outfile = Files.createTempFile("tmp", "tmp").toFile();
         gafMsg.getData(outfile);
         List<String> filenames = FileUtils.readListFromFile(outfile);
 
@@ -331,7 +332,7 @@ public class FileChecksumServerTester {
         conn.waitForConcurrentTasksToFinish();
 
         // Get the filenames
-        outfile = File.createTempFile("tmp", "tmp");
+        outfile = Files.createTempFile("tmp", "tmp").toFile();
         gafMsg.getData(outfile);
         filenames = FileUtils.readListFromFile(outfile);
 

--- a/common/common-core/src/main/java/dk/netarkivet/common/distribute/arcrepository/BitarchiveRecord.java
+++ b/common/common-core/src/main/java/dk/netarkivet/common/distribute/arcrepository/BitarchiveRecord.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.nio.file.Files;
 
 import org.archive.io.ArchiveReader;
 import org.archive.io.ArchiveReaderFactory;
@@ -121,7 +122,7 @@ public class BitarchiveRecord implements Serializable {
             } else {
                 File localTmpFile = null;
                 try {
-                    localTmpFile = File.createTempFile("BitarchiveRecord-" + fileName, ".tmp", FileUtils.getTempDir());
+                    localTmpFile = Files.createTempFile(FileUtils.getTempDir().toPath(), "BitarchiveRecord-" + fileName, ".tmp").toFile();
                     record.dump(new FileOutputStream(localTmpFile));
                     objectAsRemoteFile = RemoteFileFactory.getMovefileInstance(localTmpFile);
                     isStoredAsRemoteFile = true;

--- a/common/common-core/src/main/java/dk/netarkivet/common/distribute/arcrepository/LocalArcRepositoryClient.java
+++ b/common/common-core/src/main/java/dk/netarkivet/common/distribute/arcrepository/LocalArcRepositoryClient.java
@@ -28,6 +28,7 @@ import java.io.FileOutputStream;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -180,7 +181,7 @@ public class LocalArcRepositoryClient implements ArcRepositoryClient {
         OutputStream os = null;
         File resultFile;
         try {
-            resultFile = File.createTempFile("batch", replicaId, FileUtils.getTempDir());
+            resultFile = Files.createTempFile(FileUtils.getTempDir().toPath(), "batch", replicaId).toFile();
             os = new FileOutputStream(resultFile);
             List<File> files = new ArrayList<File>();
             final FilenameFilter filenameFilter = new FilenameFilter() {
@@ -269,7 +270,7 @@ public class LocalArcRepositoryClient implements ArcRepositoryClient {
         }
         File copiedTo = null;
         try {
-            copiedTo = File.createTempFile("removeAndGetFile", fileName);
+            copiedTo = Files.createTempFile("removeAndGetFile", fileName).toFile();
         } catch (IOException e) {
             throw new IOFailure("Cannot make temp file to copy '" + fileName + "' into", e);
         }
@@ -319,7 +320,7 @@ public class LocalArcRepositoryClient implements ArcRepositoryClient {
             }
 
             // create a file with the results.
-            File res = File.createTempFile("all", "checksums", FileUtils.getTempDir());
+            File res = Files.createTempFile(FileUtils.getTempDir().toPath(), "all", "checksums").toFile();
             FileUtils.writeCollectionToFile(res, checksums);
             return res;
         } catch (IOException e) {
@@ -349,7 +350,7 @@ public class LocalArcRepositoryClient implements ArcRepositoryClient {
         }
 
         try {
-            File res = File.createTempFile("all", "filenames", FileUtils.getTempDir());
+            File res = Files.createTempFile(FileUtils.getTempDir().toPath(), "all", "filenames").toFile();
             FileUtils.writeCollectionToFile(res, filenames);
             return res;
         } catch (IOException e) {

--- a/common/common-core/src/main/java/dk/netarkivet/common/tools/FTPValidator.java
+++ b/common/common-core/src/main/java/dk/netarkivet/common/tools/FTPValidator.java
@@ -11,6 +11,7 @@ import java.lang.reflect.Field;
 import java.net.SocketException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -411,7 +412,7 @@ public class FTPValidator {
             return false;
         }
         //upload error to ftp server
-        File temp = File.createTempFile("foo", "bar", tmpDir);
+        File temp = Files.createTempFile(tmpDir.toPath(), "foo", "bar").toFile();
         FTPClient client = new FTPClient();
         client.connect(ftpHost,ftpPort); 
         client.login(ftpUser, ftpPasswd);

--- a/common/common-core/src/main/java/dk/netarkivet/common/utils/FileUtils.java
+++ b/common/common-core/src/main/java/dk/netarkivet/common/utils/FileUtils.java
@@ -35,6 +35,7 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
@@ -1060,7 +1061,7 @@ public class FileUtils {
         for (int tries = 0; tries < MAX_RETRIES; tries++) {
             File newDir;
             try {
-                newDir = File.createTempFile(prefix, null, inDir);
+                newDir = Files.createTempFile(inDir.toPath(), prefix, null).toFile();
             } catch (IOException e) {
                 final String errMsg = "Couldn't create temporary file in '" + inDir.getAbsolutePath()
                         + "' with prefix '" + prefix + "'";
@@ -1169,7 +1170,7 @@ public class FileUtils {
 
             if (stream != null) {
                 // Make stream into file, and return it.
-                File tmpFile = File.createTempFile("tmp", "tmp");
+                File tmpFile = Files.createTempFile("tmp", "tmp").toFile();
                 StreamUtils.copyInputStreamToOutputStream(stream, new FileOutputStream(tmpFile));
                 return tmpFile;
             } else {

--- a/common/common-test/src/main/java/dk/netarkivet/common/arcrepository/TrivialArcRepositoryClient.java
+++ b/common/common-test/src/main/java/dk/netarkivet/common/arcrepository/TrivialArcRepositoryClient.java
@@ -28,6 +28,7 @@ import java.io.FileOutputStream;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.regex.Pattern;
 
 import org.archive.io.ArchiveReader;
@@ -154,7 +155,7 @@ public class TrivialArcRepositoryClient implements ArcRepositoryClient {
         OutputStream os = null;
         File resultFile;
         try {
-            resultFile = File.createTempFile("batch", replicaId, FileUtils.getTempDir());
+            resultFile = Files.createTempFile(FileUtils.getTempDir().toPath(), "batch", replicaId).toFile();
             os = new FileOutputStream(resultFile);
             File[] files = dir.listFiles(new FilenameFilter() {
                 public boolean accept(File dir, String name) {
@@ -217,7 +218,7 @@ public class TrivialArcRepositoryClient implements ArcRepositoryClient {
         // Ignores bitarchiveId, checksum, and credentials for now
         File copiedTo = null;
         try {
-            copiedTo = File.createTempFile("removeAndGetFile", fileName);
+            copiedTo = Files.createTempFile("removeAndGetFile", fileName).toFile();
         } catch (IOException e) {
             throw new IOFailure("Cannot make temp file to copy '" + fileName + "' into", e);
         }

--- a/common/common-test/src/test/java/dk/netarkivet/common/distribute/HTTPRemoteFileTester.java
+++ b/common/common-test/src/test/java/dk/netarkivet/common/distribute/HTTPRemoteFileTester.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.fail;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.URL;
+import java.nio.file.Files;
 
 import org.junit.After;
 import org.junit.Before;
@@ -74,25 +75,25 @@ public class HTTPRemoteFileTester {
     public void testCopyto() throws Exception {
         // Copying twice with multiple
         HTTPRemoteFile rf = new ForceRemoteHTTPRemoteFile(TestInfo.FILE1, false, false, true);
-        File tempFile = File.createTempFile("TEST", "COPYTO", TestInfo.WORKING_DIR);
+        File tempFile = Files.createTempFile(TestInfo.WORKING_DIR.toPath(), "TEST", "COPYTO").toFile();
         rf.copyTo(tempFile);
         String contents = FileUtils.readFile(TestInfo.FILE1);
         assertEquals("Files should be equal", contents, FileUtils.readFile(tempFile));
         assertTrue("Original file should still exist when not deletable", TestInfo.FILE1.exists());
 
-        File tempFile2 = File.createTempFile("TEST", "COPYTO", TestInfo.WORKING_DIR);
+        File tempFile2 = Files.createTempFile(TestInfo.WORKING_DIR.toPath(), "TEST", "COPYTO").toFile();
         rf.copyTo(tempFile2);
         assertEquals("Files should be equal, since multiple was true", contents, FileUtils.readFile(tempFile));
         assertTrue("Original file should still exist when not deletable", TestInfo.FILE1.exists());
 
         // Copying twice without multiple
         rf = new ForceRemoteHTTPRemoteFile(TestInfo.FILE1, false, false, false);
-        tempFile = File.createTempFile("TEST", "COPYTO", TestInfo.WORKING_DIR);
+        tempFile = Files.createTempFile(TestInfo.WORKING_DIR.toPath(), "TEST", "COPYTO").toFile();
         rf.copyTo(tempFile);
         assertEquals("Files should be equal", contents, FileUtils.readFile(tempFile));
         assertTrue("Original file should still exist when not deletable", TestInfo.FILE1.exists());
 
-        tempFile2 = File.createTempFile("TEST", "COPYTO", TestInfo.WORKING_DIR);
+        tempFile2 = Files.createTempFile(TestInfo.WORKING_DIR.toPath(), "TEST", "COPYTO").toFile();
         try {
             rf.copyTo(tempFile2);
             fail("Multiple copies should not be allowed");
@@ -102,7 +103,7 @@ public class HTTPRemoteFileTester {
 
         // Copying with non-multiple and deletable
         rf = new ForceRemoteHTTPRemoteFile(TestInfo.FILE1, false, true, false);
-        tempFile = File.createTempFile("TEST", "COPYTO", TestInfo.WORKING_DIR);
+        tempFile = Files.createTempFile(TestInfo.WORKING_DIR.toPath(), "TEST", "COPYTO").toFile();
         rf.copyTo(tempFile);
         assertEquals("Files should be equal", contents, FileUtils.readFile(tempFile));
         assertFalse("Original file shouldn't exist anymore", TestInfo.FILE1.exists());

--- a/common/common-test/src/test/java/dk/netarkivet/common/distribute/HTTPSRemoteFileTester.java
+++ b/common/common-test/src/test/java/dk/netarkivet/common/distribute/HTTPSRemoteFileTester.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.fail;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.URL;
+import java.nio.file.Files;
 
 import org.junit.After;
 import org.junit.Before;
@@ -74,25 +75,25 @@ public class HTTPSRemoteFileTester {
     public void testCopyto() throws Exception {
         // Copying twice with multiple
         HTTPSRemoteFile rf = new ForceRemoteHTTPSRemoteFile(TestInfo.FILE1, false, false, true);
-        File tempFile = File.createTempFile("TEST", "COPYTO", TestInfo.WORKING_DIR);
+        File tempFile = Files.createTempFile(TestInfo.WORKING_DIR.toPath(), "TEST", "COPYTO").toFile();
         rf.copyTo(tempFile);
         String contents = FileUtils.readFile(TestInfo.FILE1);
         assertEquals("Files should be equal", contents, FileUtils.readFile(tempFile));
         assertTrue("Original file should still exist when not deletable", TestInfo.FILE1.exists());
 
-        File tempFile2 = File.createTempFile("TEST", "COPYTO", TestInfo.WORKING_DIR);
+        File tempFile2 = Files.createTempFile(TestInfo.WORKING_DIR.toPath(), "TEST", "COPYTO").toFile();
         rf.copyTo(tempFile2);
         assertEquals("Files should be equal, since multiple was true", contents, FileUtils.readFile(tempFile));
         assertTrue("Original file should still exist when not deletable", TestInfo.FILE1.exists());
 
         // Copying twice without multiple
         rf = new ForceRemoteHTTPSRemoteFile(TestInfo.FILE1, false, false, false);
-        tempFile = File.createTempFile("TEST", "COPYTO", TestInfo.WORKING_DIR);
+        tempFile = Files.createTempFile(TestInfo.WORKING_DIR.toPath(), "TEST", "COPYTO").toFile();
         rf.copyTo(tempFile);
         assertEquals("Files should be equal", contents, FileUtils.readFile(tempFile));
         assertTrue("Original file should still exist when not deletable", TestInfo.FILE1.exists());
 
-        tempFile2 = File.createTempFile("TEST", "COPYTO", TestInfo.WORKING_DIR);
+        tempFile2 = Files.createTempFile(TestInfo.WORKING_DIR.toPath(), "TEST", "COPYTO").toFile();
         try {
             rf.copyTo(tempFile2);
             fail("Multiple copies should not be allowed");
@@ -102,7 +103,7 @@ public class HTTPSRemoteFileTester {
 
         // Copying with non-multiple and deletable
         rf = new ForceRemoteHTTPSRemoteFile(TestInfo.FILE1, false, true, false);
-        tempFile = File.createTempFile("TEST", "COPYTO", TestInfo.WORKING_DIR);
+        tempFile = Files.createTempFile(TestInfo.WORKING_DIR.toPath(), "TEST", "COPYTO").toFile();
         rf.copyTo(tempFile);
         assertEquals("Files should be equal", contents, FileUtils.readFile(tempFile));
         assertFalse("Original file shouldn't exist anymore", TestInfo.FILE1.exists());

--- a/common/common-test/src/test/java/dk/netarkivet/common/tools/RunChecksum.java
+++ b/common/common-test/src/test/java/dk/netarkivet/common/tools/RunChecksum.java
@@ -27,6 +27,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 
 import dk.netarkivet.common.CommonSettings;
@@ -73,7 +74,7 @@ public class RunChecksum {
         PreservationArcRepositoryClient arcrep = ArcRepositoryClientFactory.getPreservationInstance();
         BatchStatus lbs = arcrep.batch(new ChecksumJob(), bitarchive);
         RemoteFile result = lbs.getResultFile();
-        File localFile = File.createTempFile("checksum_tool", "results");
+        File localFile = Files.createTempFile("checksum_tool", "results").toFile();
         localFile.deleteOnExit();
         result.copyTo(localFile);
         result.cleanup();

--- a/common/common-test/src/test/java/dk/netarkivet/common/utils/FileUtilsTester.java
+++ b/common/common-test/src/test/java/dk/netarkivet/common/utils/FileUtilsTester.java
@@ -34,6 +34,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -254,7 +255,7 @@ public class FileUtilsTester {
     @Test
     public void testGetEphemeralInputStream() throws Exception {
         // Check that closing removes the file
-        File f = File.createTempFile("foo", "bar", WORKING);
+        File f = Files.createTempFile(WORKING.toPath(), "foo", "bar").toFile();
         InputStream in = FileUtils.getEphemeralInputStream(f);
         assertTrue("Temp file should exist before close", f.exists());
         in.close();

--- a/common/common-test/src/test/java/dk/netarkivet/common/utils/arc/ARCReaderUtils.java
+++ b/common/common-test/src/test/java/dk/netarkivet/common/utils/arc/ARCReaderUtils.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -70,8 +71,8 @@ public class ARCReaderUtils {
         try {
             // create an index of the arc-file
 
-            File cdxFile = File.createTempFile("reader-utils", "");
-            File cdxFileSorted = File.createTempFile("reader-utils", "");
+            File cdxFile = Files.createTempFile("reader-utils", "").toFile();
+            File cdxFileSorted = Files.createTempFile("reader-utils", "").toFile();
             CDXUtils.writeCDXInfo(ArcFile, new FileOutputStream(cdxFile));
             FileUtils.makeSortedFile(cdxFile, cdxFileSorted);
             FileUtils.copyFile(cdxFileSorted, new File("/tmp/svc/index/"));

--- a/common/common-test/src/test/java/dk/netarkivet/common/utils/batch/FileRemoverTester.java
+++ b/common/common-test/src/test/java/dk/netarkivet/common/utils/batch/FileRemoverTester.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertFalse;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import org.junit.Test;
 
@@ -39,7 +40,7 @@ public class FileRemoverTester {
         FileBatchJob job = new FileRemover();
         job.initialize(null);
         File tmp = null;
-        tmp = File.createTempFile("test", "fileremover");
+        tmp = Files.createTempFile("test", "fileremover").toFile();
         job.processFile(tmp, null);
         job.finish(null);
         assertFalse(tmp.exists());

--- a/deploy/deploy-test/src/test/java/dk/netarkivet/common/distribute/IntegrityTestsFTP.java
+++ b/deploy/deploy-test/src/test/java/dk/netarkivet/common/distribute/IntegrityTestsFTP.java
@@ -37,6 +37,7 @@ import java.io.InputStream;
 import java.io.PrintWriter;
 import java.lang.reflect.Field;
 import java.net.SocketException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -398,7 +399,7 @@ public class IntegrityTestsFTP {
         Settings.set(CommonSettings.REMOTE_FILE_CLASS, "dk.netarkivet.common.distribute.FTPRemoteFile");
         RemoteFile rf = RemoteFileFactory.getInstance(testFile2, true, false, true);
         // upload error to ftp server
-        File temp = File.createTempFile("foo", "bar");
+        File temp = Files.createTempFile("foo", "bar").toFile();
         FTPClient client = new FTPClient();
         client.connect(Settings.get(CommonSettings.FTP_SERVER_NAME),
                 Integer.parseInt(Settings.get(CommonSettings.FTP_SERVER_PORT)));

--- a/harvester/harvester-core/src/main/java/dk/netarkivet/harvester/harvesting/monitor/StartedJobHistoryChartGen.java
+++ b/harvester/harvester-core/src/main/java/dk/netarkivet/harvester/harvesting/monitor/StartedJobHistoryChartGen.java
@@ -25,6 +25,7 @@ package dk.netarkivet.harvester.harvesting.monitor;
 import java.awt.Color;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.text.DecimalFormat;
 import java.util.LinkedList;
 import java.util.Locale;
@@ -180,7 +181,7 @@ class StartedJobHistoryChartGen {
 
             File newPngFile;
             try {
-                newPngFile = File.createTempFile(jobId + "-history", "." + System.currentTimeMillis() + ".png");
+                newPngFile = Files.createTempFile(jobId + "-history", "." + System.currentTimeMillis() + ".png").toFile();
             } catch (IOException e) {
                 LOG.warn("Failed to create temp PNG file for job " + jobId);
                 return;

--- a/harvester/harvester-core/src/main/java/dk/netarkivet/harvester/indexserver/CrawlLogIndexCache.java
+++ b/harvester/harvester-core/src/main/java/dk/netarkivet/harvester/indexserver/CrawlLogIndexCache.java
@@ -27,6 +27,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -363,7 +364,7 @@ public abstract class CrawlLogIndexCache extends CombiningMultiFileBasedCache<Lo
      */
     protected static File getSortedCDX(File cdxFile) {
         try {
-            final File tmpFile = File.createTempFile("sorted", "cdx", FileUtils.getTempDir());
+            final File tmpFile = Files.createTempFile(FileUtils.getTempDir().toPath(), "sorted", "cdx").toFile();
             // This throws IOFailure, if the sorting operation fails
             FileUtils.sortCDX(cdxFile, tmpFile);
             tmpFile.deleteOnExit();
@@ -382,7 +383,7 @@ public abstract class CrawlLogIndexCache extends CombiningMultiFileBasedCache<Lo
      */
     protected static File getSortedCrawlLog(File file) {
         try {
-            File tmpCrawlLog = File.createTempFile("sorted", "crawllog", FileUtils.getTempDir());
+            File tmpCrawlLog = Files.createTempFile(FileUtils.getTempDir().toPath(), "sorted", "crawllog").toFile();
             // This throws IOFailure, if the sorting operation fails
             FileUtils.sortCrawlLog(file, tmpCrawlLog);
             tmpCrawlLog.deleteOnExit();

--- a/harvester/harvester-core/src/main/java/dk/netarkivet/harvester/indexserver/RawMetadataCache.java
+++ b/harvester/harvester-core/src/main/java/dk/netarkivet/harvester/indexserver/RawMetadataCache.java
@@ -237,7 +237,7 @@ public class RawMetadataCache extends FileBasedCache<Long> implements RawDataCac
             File cacheFileName) {
         File migration = null;
         try {
-            migration = File.createTempFile("migration", "txt");
+            migration = Files.createTempFile("migration", "txt").toFile();
         } catch (IOException e) {
             throw new IOFailure("Could not create temporary output file.");
         }
@@ -264,7 +264,7 @@ public class RawMetadataCache extends FileBasedCache<Long> implements RawDataCac
     private File createTempOutputFile() {
         File crawllog = null;
         try {
-            crawllog = File.createTempFile("dedup", "txt");
+            crawllog = Files.createTempFile("dedup", "txt").toFile();
         } catch (IOException e) {
             throw new IOFailure("Could not create temporary output file.");
         }
@@ -369,7 +369,7 @@ public class RawMetadataCache extends FileBasedCache<Long> implements RawDataCac
             BatchStatus b2 = arcrep.batch(job2, replicaUsed);
             File migration = null;
             try {
-                migration = File.createTempFile("migration", "txt");
+                migration = Files.createTempFile("migration", "txt").toFile();
             } catch (IOException e) {
                 throw new IOFailure("Could not create temporary output file.");
             }

--- a/harvester/harvester-core/src/main/java/dk/netarkivet/harvester/indexserver/distribute/IndexRequestClient.java
+++ b/harvester/harvester-core/src/main/java/dk/netarkivet/harvester/indexserver/distribute/IndexRequestClient.java
@@ -24,6 +24,7 @@ package dk.netarkivet.harvester.indexserver.distribute;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
@@ -251,7 +252,7 @@ public class IndexRequestClient extends MultiFileBasedCache<Long> implements Job
         File tmpFile = null;
         try {
             // We cannot unzip directly from a stream, so we make a temp file.
-            tmpFile = File.createTempFile("remotefile-unzip", ".gz", FileUtils.getTempDir());
+            tmpFile = Files.createTempFile(FileUtils.getTempDir().toPath(), "remotefile-unzip", ".gz").toFile();
             remoteFile.copyTo(tmpFile);
             ZipUtils.gunzipFile(tmpFile, destFile);
             try {

--- a/harvester/harvester-core/src/main/java/dk/netarkivet/harvester/tools/FindRelevantCrawllogLines.java
+++ b/harvester/harvester-core/src/main/java/dk/netarkivet/harvester/tools/FindRelevantCrawllogLines.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.List;
 
 import dk.netarkivet.common.utils.batch.BatchLocalFiles;
@@ -37,7 +38,7 @@ public class FindRelevantCrawllogLines {
 					+ metadatafile.getAbsolutePath());
 			System.exit(1);
 		}
-		File resultFile1 = File.createTempFile("FindRelevant", "matchingLines", new File("/tmp"));
+		File resultFile1 = Files.createTempFile(new File("/tmp").toPath(), "FindRelevant", "matchingLines").toFile();
 		
 		String regexp = getRegexpToFindDomainLines(domain);
 		File resultFile = resultFile1;	

--- a/harvester/harvester-core/src/main/java/dk/netarkivet/harvester/webinterface/EventHarvestUtil.java
+++ b/harvester/harvester-core/src/main/java/dk/netarkivet/harvester/webinterface/EventHarvestUtil.java
@@ -25,6 +25,7 @@ package dk.netarkivet.harvester.webinterface;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -74,7 +75,7 @@ public final class EventHarvestUtil {
     		addConfigurations(pageContext, I18N, harvestName, illegalSeeds);
     	} else {
     		//the new seeds is contained indirectly in the formdata in a separate file.
-    		File seedsFile = File.createTempFile("seeds", ".txt", FileUtils.getTempDir());
+    		File seedsFile = Files.createTempFile(FileUtils.getTempDir().toPath(), "seeds", ".txt").toFile();
     		try {
 				processMultidataForm(pageContext, seedsFile, attributeMap);
 			} catch (Throwable e) {

--- a/harvester/harvester-core/src/main/java/dk/netarkivet/viewerproxy/GetDataResolver.java
+++ b/harvester/harvester-core/src/main/java/dk/netarkivet/viewerproxy/GetDataResolver.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.nio.file.Files;
 import java.util.Arrays;
 
 import org.slf4j.Logger;
@@ -205,7 +206,7 @@ public class GetDataResolver extends CommandResolver {
     	try {
     		File tempFile = null;
     		try {
-    			tempFile = File.createTempFile(fileName, "download", FileUtils.getTempDir());
+    			tempFile = Files.createTempFile(FileUtils.getTempDir().toPath(), fileName, "download").toFile();
     			client.getFile(fileName, Replica.getReplicaFromId(Settings.get(CommonSettings.USE_REPLICA_ID)),
     					tempFile);
     			long size = tempFile.length();

--- a/harvester/harvester-core/src/main/java/dk/netarkivet/viewerproxy/webinterface/Reporting.java
+++ b/harvester/harvester-core/src/main/java/dk/netarkivet/viewerproxy/webinterface/Reporting.java
@@ -143,7 +143,7 @@ public class Reporting {
         fileListJob.processOnlyFilesMatching(acceptedPatterns);
         File f;
         try {
-            f = File.createTempFile(jobid + "-files", ".txt", FileUtils.getTempDir());
+            f = Files.createTempFile(FileUtils.getTempDir().toPath(), jobid + "-files", ".txt").toFile();
         } catch (IOException e) {
             throw new IOFailure("Could not create temporary file", e);
         }
@@ -257,7 +257,7 @@ public class Reporting {
 
         File f;
         try {
-            f = File.createTempFile(jobid + "-reports", ".cdx", FileUtils.getTempDir());
+            f = Files.createTempFile(FileUtils.getTempDir().toPath(), jobid + "-reports", ".cdx").toFile();
         } catch (IOException e) {
             throw new IOFailure("Could not create temporary file", e);
         }
@@ -309,7 +309,7 @@ public class Reporting {
     private static File createTempResultFile(String uuidSuffix) {
         File tempFile;
         try {
-            tempFile = File.createTempFile("temp", uuidSuffix + ".txt", FileUtils.getTempDir());
+            tempFile = Files.createTempFile(FileUtils.getTempDir().toPath(), "temp", uuidSuffix + ".txt").toFile();
             tempFile.deleteOnExit();
         } catch (IOException e) {
             throw new IOFailure("Unable to create temporary file", e);
@@ -522,8 +522,8 @@ public class Reporting {
             job.processOnlyFilesMatching(metadataFileSearchPattern);
             job.prepareJobInputOutput(fileSystem);
             job.run();
-            File tempOutputFile1 = File.createTempFile("unsorted_crawl", "log");
-            File tempOutputFile2 = File.createTempFile("sorted_crawl", "log");
+            File tempOutputFile1 = Files.createTempFile("unsorted_crawl", "log").toFile();
+            File tempOutputFile2 = Files.createTempFile("sorted_crawl", "log").toFile();
             log.info("Collecting output from {} to {}", job.getJobOutputDir(), tempOutputFile1.getAbsolutePath());
             try (OutputStream os = new FileOutputStream(tempOutputFile1)) {
                 HadoopJobUtils.collectOutputLines(fileSystem, job.getJobOutputDir(), os);

--- a/harvester/harvester-core/src/test/java/dk/netarkivet/harvester/harvesting/metadata/MetadataFileWriterTester.java
+++ b/harvester/harvester-core/src/test/java/dk/netarkivet/harvester/harvesting/metadata/MetadataFileWriterTester.java
@@ -24,6 +24,7 @@ package dk.netarkivet.harvester.harvesting.metadata;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -129,7 +130,7 @@ public class MetadataFileWriterTester {
         textArray.add(someText);
         Set<File> files = new HashSet<>();
         for (int i = 0; i < 10000; i++) {
-            File f = File.createTempFile("metadata", "cdx");
+            File f = Files.createTempFile("metadata", "cdx").toFile();
             FileUtils.writeCollectionToFile(f, textArray);
             files.add(f);
         }

--- a/harvester/harvester-test/src/test/java/dk/netarkivet/harvester/indexserver/distribute/IndexRequestMessageTester.java
+++ b/harvester/harvester-test/src/test/java/dk/netarkivet/harvester/indexserver/distribute/IndexRequestMessageTester.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -144,8 +145,8 @@ public class IndexRequestMessageTester {
             assertTrue("Should be the right exception", e.getMessage().contains("resultFile"));
         }
         assertNull("No index file yet", irMsg.getResultFiles());
-        File tempFile = File.createTempFile("temp", "temp", TestInfo.WORKING_DIR);
-        File tempFile2 = File.createTempFile("temp", "temp", TestInfo.WORKING_DIR);
+        File tempFile = Files.createTempFile(TestInfo.WORKING_DIR.toPath(), "temp", "temp").toFile();
+        File tempFile2 = Files.createTempFile(TestInfo.WORKING_DIR.toPath(), "temp", "temp").toFile();
         List<RemoteFile> resultFiles = new ArrayList<RemoteFile>(2);
         resultFiles.add(new TestRemoteFile(tempFile, false, false, false));
         resultFiles.add(new TestRemoteFile(tempFile2, false, false, false));
@@ -179,7 +180,7 @@ public class IndexRequestMessageTester {
             assertTrue("Should be the right exception", e.getMessage().contains("resultFile"));
         }
         assertNull("No index file yet", irMsg.getResultFiles());
-        File tempFile = File.createTempFile("temp", "temp", TestInfo.WORKING_DIR);
+        File tempFile = Files.createTempFile(TestInfo.WORKING_DIR.toPath(), "temp", "temp").toFile();
         irMsg.setResultFile(new TestRemoteFile(tempFile, false, false, false));
         assertEquals("Should have index file .", tempFile.getName(), irMsg.getResultFile().getName());
         assertFalse("Should be a single-file message", irMsg.isIndexIsStoredInDirectory());
@@ -238,7 +239,7 @@ public class IndexRequestMessageTester {
         assertEquals("Must deserialize to same state", relevantState(irMsg), relevantState(irMsg2));
         irMsg.setNotOk("AARGH");
         irMsg.setFoundJobs(JOB_SET);
-        File tempFile = File.createTempFile("temp", "temp");
+        File tempFile = Files.createTempFile("temp", "temp").toFile();
         tempFile.deleteOnExit();
         List<RemoteFile> resultFiles = new ArrayList<RemoteFile>(1);
         resultFiles.add(new TestRemoteFile(tempFile, false, false, false));

--- a/harvester/harvester-test/src/test/java/dk/netarkivet/harvester/indexserver/distribute/IndexRequestServerTester.java
+++ b/harvester/harvester-test/src/test/java/dk/netarkivet/harvester/indexserver/distribute/IndexRequestServerTester.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.fail;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -210,7 +211,7 @@ public class IndexRequestServerTester {
         assertTrue("Should be OK", msg.isOk());
 
         // Check contents of file replied
-        File extractFile = File.createTempFile("extr", "act", TestInfo.WORKING_DIR);
+        File extractFile = Files.createTempFile(TestInfo.WORKING_DIR.toPath(), "extr", "act").toFile();
         assertFalse("Message should not indicate directory", msg.isIndexIsStoredInDirectory());
         RemoteFile resultFile = msg.getResultFile();
         resultFile.copyTo(extractFile);

--- a/harvester/harvester-test/src/test/java/dk/netarkivet/harvester/webinterface/servlet/NASEnvironmentTester.java
+++ b/harvester/harvester-test/src/test/java/dk/netarkivet/harvester/webinterface/servlet/NASEnvironmentTester.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
+import java.nio.file.Files;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
@@ -48,7 +49,7 @@ public class NASEnvironmentTester extends DataModelTestCase {
                 + "2005-05-06T11:47:34.753Z -9998          - https://rex.qb.dk/F L http://www.qb.dk/ no-type #030 - - 3t\n"
                 + "2005-05-06T11:47:30.544Z   200      13750 http://www.kb.dk/ - - text/html #001 20050506114730466+32 U4X3Z5EGCNUYTMIXST6BJXGA5SBKTEAJ 3t\n";
 
-        File tempFile = File.createTempFile("NASEnvironmentTest-mock-crawllog-", ".tmp");
+        File tempFile = Files.createTempFile("NASEnvironmentTest-mock-crawllog-", ".tmp").toFile();
         tempFile.deleteOnExit();
         String crawlLogFilePath = tempFile.getAbsolutePath();
 

--- a/harvester/harvester-test/src/test/java/dk/netarkivet/viewerproxy/webinterface/hadoop/CrawlLogExtractionMapperTester.java
+++ b/harvester/harvester-test/src/test/java/dk/netarkivet/viewerproxy/webinterface/hadoop/CrawlLogExtractionMapperTester.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.UUID;
 
@@ -45,7 +46,7 @@ public class CrawlLogExtractionMapperTester extends HadoopMiniClusterTestCase {
     public void testGetCrawlLogWARCMetadataFile() throws Exception {
         String outputURI = "hdfs://localhost:" + hdfsCluster.getNameNodePort() + "/" + UUID.randomUUID().toString();
         // Write the input lines to the the input file
-        File jobInputFile = File.createTempFile("tmp", UUID.randomUUID().toString());
+        File jobInputFile = Files.createTempFile("tmp", UUID.randomUUID().toString()).toFile();
         org.apache.commons.io.FileUtils.writeStringToFile(jobInputFile, "file://" + WARC_FILE.getAbsolutePath());
         jobInputFile.deleteOnExit();
         String regex = ".*(https?:\\/\\/(www\\.)?|dns:|ftp:\\/\\/)([\\w_-]+\\.)?([\\w_-]+\\.)?([\\w_-]+\\.)?"
@@ -84,7 +85,7 @@ public class CrawlLogExtractionMapperTester extends HadoopMiniClusterTestCase {
     public void testGetCrawlLogARCMetadataFile() throws Exception {
         String outputURI = "hdfs://localhost:" + hdfsCluster.getNameNodePort() + "/" + UUID.randomUUID().toString();
         // Write the input lines to the the input file
-        File jobInputFile = File.createTempFile("tmp", UUID.randomUUID().toString());
+        File jobInputFile = Files.createTempFile("tmp", UUID.randomUUID().toString()).toFile();
         org.apache.commons.io.FileUtils.writeStringToFile(jobInputFile, "file://" + ARC_FILE.getAbsolutePath());
         jobInputFile.deleteOnExit();
         String regex = ".*(https?:\\/\\/(www\\.)?|dns:|ftp:\\/\\/)([\\w_-]+\\.)?([\\w_-]+\\.)?([\\w_-]+\\.)?"
@@ -125,7 +126,7 @@ public class CrawlLogExtractionMapperTester extends HadoopMiniClusterTestCase {
     private static File createTempResultFile(String uuidSuffix) {
         File tempFile;
         try {
-            tempFile = File.createTempFile("temp", uuidSuffix + ".txt");
+            tempFile = Files.createTempFile("temp", uuidSuffix + ".txt").toFile();
             tempFile.deleteOnExit();
         } catch (IOException e) {
             throw new IOFailure("Unable to create temporary file", e);

--- a/harvester/harvester-test/src/test/java/dk/netarkivet/viewerproxy/webinterface/hadoop/MetadataCDXMapperTester.java
+++ b/harvester/harvester-test/src/test/java/dk/netarkivet/viewerproxy/webinterface/hadoop/MetadataCDXMapperTester.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.UUID;
 
@@ -44,7 +45,7 @@ public class MetadataCDXMapperTester extends HadoopMiniClusterTestCase {
     public void testCDXIndexWARCMetadataFile() throws Exception {
         String outputURI = "hdfs://localhost:" + hdfsCluster.getNameNodePort() + "/" + UUID.randomUUID().toString();
         // Write the input lines to the the input file
-        File jobInputFile = File.createTempFile("tmp", UUID.randomUUID().toString());
+        File jobInputFile = Files.createTempFile("tmp", UUID.randomUUID().toString()).toFile();
         org.apache.commons.io.FileUtils.writeStringToFile(jobInputFile, "file://" + WARC_FILE.getAbsolutePath());
         jobInputFile.deleteOnExit();
 
@@ -71,7 +72,7 @@ public class MetadataCDXMapperTester extends HadoopMiniClusterTestCase {
     public void testCDXIndexARCMetadataFile() throws Exception {
         String outputURI = "hdfs://localhost:" + hdfsCluster.getNameNodePort() + "/" + UUID.randomUUID().toString();
         // Write the input lines to the the input file
-        File jobInputFile = File.createTempFile("tmp", UUID.randomUUID().toString());
+        File jobInputFile = Files.createTempFile("tmp", UUID.randomUUID().toString()).toFile();
         org.apache.commons.io.FileUtils.writeStringToFile(jobInputFile, "file://" + ARC_FILE.getAbsolutePath());
         jobInputFile.deleteOnExit();
 

--- a/harvester/heritrix3/heritrix3-controller/src/main/java/dk/netarkivet/harvester/tools/CreateCDXMetadataFile.java
+++ b/harvester/heritrix3/heritrix3-controller/src/main/java/dk/netarkivet/harvester/tools/CreateCDXMetadataFile.java
@@ -28,6 +28,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -256,7 +257,7 @@ public class CreateCDXMetadataFile extends ToolRunnerBase {
                 System.out.println("Got results from archive. Processing data");
                 File resultFile = null;
                 try {
-                    resultFile = File.createTempFile("extract-batch", ".cdx", FileUtils.getTempDir());
+                    resultFile = Files.createTempFile(FileUtils.getTempDir().toPath(), "extract-batch", ".cdx").toFile();
                     resultFile.deleteOnExit();
                     status.copyResults(resultFile);
                     arcifyResultFile(resultFile, jobID, harvestId);

--- a/harvester/heritrix3/heritrix3-controller/src/test/java/dk/netarkivet/harvester/harvesting/report/HarvestReportGeneratorTest.java
+++ b/harvester/heritrix3/heritrix3-controller/src/test/java/dk/netarkivet/harvester/harvesting/report/HarvestReportGeneratorTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Set;
 
 import org.junit.Test;
@@ -36,8 +37,8 @@ public class HarvestReportGeneratorTest {
 	public void testReportGenerator() throws IOException {
 		File crawldir = new File("src/test/resources/crawldir");
 		PersistentJobData pjd = new PersistentJobData(crawldir);
-		File h3Bundle = File.createTempFile("fake-path-to-h3-bundle", "");
-		File certificat = File.createTempFile("fake-path-to-h3-certificat", "");
+		File h3Bundle = Files.createTempFile("fake-path-to-h3-bundle", "").toFile();
+		File certificat = Files.createTempFile("fake-path-to-h3-certificat", "").toFile();
 		Settings.set(HarvesterSettings.HERITRIX3_BUNDLE, h3Bundle.getAbsolutePath());
 		Settings.set(HarvesterSettings.HERITRIX3_CERTIFICATE, certificat.getAbsolutePath());
 		Heritrix3Files files = Heritrix3Files.getH3HeritrixFiles(crawldir, 

--- a/integration-test/system-test/src/test/java/dk/netarkivet/systemtest/performance/IngestDomainJob.java
+++ b/integration-test/system-test/src/test/java/dk/netarkivet/systemtest/performance/IngestDomainJob.java
@@ -7,6 +7,7 @@ import static org.testng.Assert.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -45,7 +46,7 @@ class IngestDomainJob extends GenericWebJob {
         stressTest.addFixture("Opening initial page " + baseUrl);
         File domainsFile = null;
         try {
-            domainsFile = File.createTempFile("domains", "txt", new File("."));
+            domainsFile = Files.createTempFile(new File(".").toPath(), "domains", "txt").toFile();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -62,7 +63,7 @@ class IngestDomainJob extends GenericWebJob {
         stressTest.addStep("Checking for existence of domains file", "The file should exist.");
         if (!backupEnv.equals("prod")) {
             File tempFile = null;
-            tempFile = File.createTempFile("domains", "txt", new File("."));
+            tempFile = Files.createTempFile(new File(".").toPath(), "domains", "txt").toFile();
             LineIterator lineIterator = FileUtils.lineIterator(domainsFile);
             List<String> lines = new ArrayList<>();
             int lineCount=0;

--- a/wayback/wayback-indexer/src/main/java/dk/netarkivet/wayback/indexer/ArchiveFile.java
+++ b/wayback/wayback-indexer/src/main/java/dk/netarkivet/wayback/indexer/ArchiveFile.java
@@ -259,8 +259,7 @@ public class ArchiveFile {
 
     private void createJobInputFile(String filename, Path jobInputFile, FileSystem fileSystem) throws IOException {
         //Create the input file locally
-        File localInputTempFile = File.createTempFile("cdxextract", ".txt",
-                Settings.getFile(CommonSettings.DIR_COMMONTEMPDIR));
+        File localInputTempFile = Files.createTempFile(Settings.getFile(CommonSettings.DIR_COMMONTEMPDIR).toPath(), "cdxextract", ".txt").toFile();
         FileResolver fileResolver = SettingsFactory.getInstance(CommonSettings.FILE_RESOLVER_CLASS);
         if (fileResolver instanceof SimpleFileResolver) {
             String pillarParentDir = Settings.get(CommonSettings.HADOOP_MAPRED_INPUT_FILES_PARENT_DIR);

--- a/wayback/wayback-test/src/test/java/dk/netarkivet/wayback/hadoop/CDXMapperTester.java
+++ b/wayback/wayback-test/src/test/java/dk/netarkivet/wayback/hadoop/CDXMapperTester.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.UUID;
 
@@ -42,7 +43,7 @@ public class CDXMapperTester extends HadoopMiniClusterTestCase {
         String outputURI = "hdfs://localhost:" + hdfsCluster.getNameNodePort() + "/" + UUID.randomUUID().toString();
         // Write the input lines to the the input file
         File testFile = new File(WORKING_DIR, "12345-metadata-4.arc");
-        File jobInputFile = File.createTempFile("tmp", UUID.randomUUID().toString());
+        File jobInputFile = Files.createTempFile("tmp", UUID.randomUUID().toString()).toFile();
         org.apache.commons.io.FileUtils.writeStringToFile(jobInputFile, "file://" + testFile.getAbsolutePath());
         jobInputFile.deleteOnExit();
 
@@ -71,7 +72,7 @@ public class CDXMapperTester extends HadoopMiniClusterTestCase {
     public void testCDXIndexStandardARCFile() throws Exception {
         File testFile = new File(WORKING_DIR, "arcfile_withredirects.arc");
         String outputURI = "hdfs://localhost:" + hdfsCluster.getNameNodePort() + "/" + UUID.randomUUID().toString();
-        File jobInputFile = File.createTempFile("tmp", UUID.randomUUID().toString());
+        File jobInputFile = Files.createTempFile("tmp", UUID.randomUUID().toString()).toFile();
         org.apache.commons.io.FileUtils.writeStringToFile(jobInputFile, "file://" + testFile.getAbsolutePath());
         jobInputFile.deleteOnExit();
 
@@ -99,7 +100,7 @@ public class CDXMapperTester extends HadoopMiniClusterTestCase {
     public void testCDXIndexStandardWARCFile() throws Exception {
         File testFile = new File(WORKING_DIR,"warcfile_withredirects.warc");
         String outputURI = "hdfs://localhost:" + hdfsCluster.getNameNodePort() + "/" + UUID.randomUUID().toString();
-        File jobInputFile = File.createTempFile("tmp", UUID.randomUUID().toString());
+        File jobInputFile = Files.createTempFile("tmp", UUID.randomUUID().toString()).toFile();
         org.apache.commons.io.FileUtils.writeStringToFile(jobInputFile, "file://" + testFile.getAbsolutePath());
         jobInputFile.deleteOnExit();
 


### PR DESCRIPTION

# Security Vulnerability Fix

This pull request fixes a Temporary File Information Disclosure Vulnerability, which existed in this project.

## Preamble

The system temporary directory is shared between all users on most unix-like systems (not MacOS, or Windows). Thus, code interacting with the system temporary directory must be careful about file interactions in this directory, and must ensure that the correct file posix permissions are set.

This PR was generated because a call to `File.createTempFile(..)` was detected in this repository in a way that makes this project vulnerable to local information disclosure.
With the default uname configuration, `File.createTempFile(..)` creates a file with the permissions `-rw-r--r--`. This means that any other user on the system can read the contents of this file.

### Impact

Information in this file is visible to other local users, allowing a malicious actor co-resident on the same machine to view potentially sensitive files.

#### Other Examples

 - [CVE-2020-15250](https://github.com/advisories/GHSA-269g-pwp5-87pp) - junit-team/junit
 - [CVE-2021-21364](https://github.com/advisories/GHSA-hpv8-9rq5-hq7w) - swagger-api/swagger-codegen
 - [CVE-2022-24823](https://github.com/advisories/GHSA-5mcr-gq6c-3hq2) - netty/netty
 - [CVE-2022-24823](https://github.com/advisories/GHSA-269q-hmxg-m83q) - netty/netty

# The Fix

The fix has been to convert the logic above to use the following API that was introduced in Java 1.7.

```java
File tmpDir = Files.createTempFile("temp dir").toFile();
```

The API both creates the file securely, ie. with a random, non-conflicting name, with file permissions that only allow the currently executing user to read or write the contents of this file.
By default, `Files.createTempFile("temp dir")` will create a file with the permissions `-rw-------`, which only allows the user that created the file to view/write the file contents.

# :arrow_right: Vulnerability Disclosure :arrow_left:

:wave: Vulnerability disclosure is a super important part of the vulnerability handling process and should not be skipped! This may be completely new to you, and that's okay, I'm here to assist!

First question, do we need to perform vulnerability disclosure? It depends!

 1. Is the vulnerable code only in tests or example code? No disclosure required!
 2. Is the vulnerable code in code shipped to your end users? Vulnerability disclosure is probably required!

## Vulnerability Disclosure How-To

You have a few options options to perform vulnerability disclosure. However, I'd like to suggest the following 2 options:

 1. Request a CVE number from GitHub by creating a repository-level [GitHub Security Advisory](https://docs.github.com/en/code-security/repository-security-advisories/creating-a-repository-security-advisory). This has the advantage that, if you provide sufficient information, GitHub will automatically generate Dependabot alerts for your downstream consumers, resolving this vulnerability more quickly.
 2. Reach out to the team at Snyk to assist with CVE issuance. They can be reached at the [Snyk's Disclosure Email](mailto:report@snyk.io).

## Detecting this and Future Vulnerabilities

This vulnerability was automatically detected by GitHub's CodeQL using this [CodeQL Query](https://codeql.github.com/codeql-query-help/java/java-local-temp-file-or-directory-information-disclosure/).

You can automatically detect future vulnerabilities like this by enabling the free (for open-source) [GitHub Action](https://github.com/github/codeql-action).

I'm not an employee of GitHub, I'm simply an open-source security researcher.

## Source

This contribution was automatically generated with an [OpenRewrite](https://github.com/openrewrite/rewrite) [refactoring recipe](https://docs.openrewrite.org/), which was lovingly hand crafted to bring this security fix to your repository.

The source code that generated this PR can be found here:
[SecureTempFileCreation](https://github.com/openrewrite/rewrite-java-security/blob/main/src/main/java/org/openrewrite/java/security/SecureTempFileCreation.java)

## Opting-Out

If you'd like to opt-out of future automated security vulnerability fixes like this, please consider adding a file called
`.github/GH-ROBOTS.txt` to your repository with the line:

```
User-agent: JLLeitschuh/security-research
Disallow: *
```

This bot will respect the [ROBOTS.txt](https://moz.com/learn/seo/robotstxt) format for future contributions.

Alternatively, if this project is no longer actively maintained, consider [archiving](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-archiving-repositories) the repository.

## CLA Requirements

_This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions._

It is unlikely that I'll be able to directly sign CLAs. However, all contributed commits are already automatically signed-off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin
> (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit Signoff documentation](https://developercertificate.org/)

If signing your organization's CLA is a strict-requirement for merging this contribution, please feel free to close this PR.

## Sponsorship & Support

This contribution is sponsored by HUMAN Security Inc. and the new Dan Kaminsky Fellowship, a fellowship created to celebrate Dan's memory and legacy by funding open-source work that makes the world a better (and more secure) place.

This PR was generated by [Moderne](https://www.moderne.io/), a free-for-open source SaaS offering that uses format-preserving AST transformations to fix bugs, standardize code style, apply best practices, migrate library versions, and fix common security vulnerabilities at scale.

## Tracking

All PR's generated as part of this fix are tracked here: https://github.com/JLLeitschuh/security-research/issues/18
