### PR TITLE
Updated heritrix (3.10.0) and webarchive-commons (2.0.1)

### DIFF
--- a/common/common-core/src/main/java/dk/netarkivet/common/utils/FixedUURI.java
+++ b/common/common-core/src/main/java/dk/netarkivet/common/utils/FixedUURI.java
@@ -23,7 +23,7 @@
 
 package dk.netarkivet.common.utils;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.url.UsableURI;
 
 /**

--- a/common/common-core/src/main/java/dk/netarkivet/common/utils/arc/ARCUtils.java
+++ b/common/common-core/src/main/java/dk/netarkivet/common/utils/arc/ARCUtils.java
@@ -36,6 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.archive.format.ArchiveFileConstants;
 import org.archive.format.arc.ARCConstants;
 import org.archive.io.ArchiveRecord;
 import org.archive.io.WriterPoolSettings;
@@ -282,19 +283,19 @@ public final class ARCUtils {
     public static Map<String, Object> getHeadersFromARCFile(InputStream in, Long offset) throws IOException {
         Map<String, Object> headers = new HashMap<String, Object>();
         // extra needed headers.
-        headers.put(ARCRecordMetaData.VERSION_FIELD_KEY, "");
-        headers.put(ARCRecordMetaData.ABSOLUTE_OFFSET_KEY, offset);
+        headers.put(ArchiveFileConstants.VERSION_FIELD_KEY, "");
+        headers.put(ArchiveFileConstants.ABSOLUTE_OFFSET_KEY, offset);
 
         String line = InputStreamUtils.readLine(in);
         String[] tmp = line.split(" ");
 
         // decode header.
         if (tmp.length == 5) {
-            headers.put(ARCRecordMetaData.URL_FIELD_KEY, tmp[0]);
-            headers.put(ARCRecordMetaData.IP_HEADER_FIELD_KEY, tmp[1]);
-            headers.put(ARCRecordMetaData.DATE_FIELD_KEY, tmp[2]);
-            headers.put(ARCRecordMetaData.MIMETYPE_FIELD_KEY, tmp[3]);
-            headers.put(ARCRecordMetaData.LENGTH_FIELD_KEY, tmp[4]);
+            headers.put(ArchiveFileConstants.URL_FIELD_KEY, tmp[0]);
+            headers.put(ARCConstants.IP_HEADER_FIELD_KEY, tmp[1]);
+            headers.put(ArchiveFileConstants.DATE_FIELD_KEY, tmp[2]);
+            headers.put(ArchiveFileConstants.MIMETYPE_FIELD_KEY, tmp[3]);
+            headers.put(ArchiveFileConstants.LENGTH_FIELD_KEY, tmp[4]);
         } else {
             throw new IOException("Does not include required metadata to be a valid ARC header: " + line);
         }
@@ -303,7 +304,7 @@ public final class ARCUtils {
         Matcher m = HTTP_HEADER_PATTERN.matcher(line);
 
         if (m.matches()) {
-            headers.put(ARCRecordMetaData.STATUSCODE_FIELD_KEY, m.group(1));
+            headers.put(ARCConstants.STATUSCODE_FIELD_KEY, m.group(1));
             // not valid META DATA
             headers.put(RESPONSETEXT, line);
         }

--- a/common/common-core/src/test/java/dk/netarkivet/common/utils/FixedUUURITest.java
+++ b/common/common-core/src/test/java/dk/netarkivet/common/utils/FixedUUURITest.java
@@ -24,7 +24,7 @@ package dk.netarkivet.common.utils;
 
 import static org.junit.Assert.fail;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.url.UsableURI;
 import org.junit.Test;
 

--- a/common/common-test/src/test/java/dk/netarkivet/common/utils/cdx/ExtractCDXFromWarcJob.java
+++ b/common/common-test/src/test/java/dk/netarkivet/common/utils/cdx/ExtractCDXFromWarcJob.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.archive.format.warc.WARCConstants;
 import org.archive.io.ArchiveRecord;
 import org.archive.io.arc.ARCRecord;
 import org.archive.io.warc.WARCRecord;
@@ -123,8 +124,8 @@ public class ExtractCDXFromWarcJob extends ArchiveBatchJob {
             ip = ((ARCRecord) rec).getMetaData().getIp();
             archiveFilename = ((ARCRecord) rec).getMetaData().getArcFile().getName();
         } else if (rec instanceof WARCRecord) {
-            ip = (String) rec.getHeader().getHeaderValue(WARCRecord.HEADER_KEY_IP);
-            archiveFilename = (String) rec.getHeader().getHeaderValue(WARCRecord.HEADER_KEY_FILENAME);
+            ip = (String) rec.getHeader().getHeaderValue(WARCConstants.HEADER_KEY_IP);
+            archiveFilename = (String) rec.getHeader().getHeaderValue(WARCConstants.HEADER_KEY_FILENAME);
         } else {
             throw new ArgumentNotValid("Do not know how to find the IP and filename for this type of ArchiveRecord: "
                     + rec.getClass().getName());

--- a/harvester/heritrix3/heritrix3-controller/src/main/java/dk/netarkivet/harvester/heritrix3/report/HarvestReportGenerator.java
+++ b/harvester/heritrix3/heritrix3-controller/src/main/java/dk/netarkivet/harvester/heritrix3/report/HarvestReportGenerator.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.url.UsableURI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/harvester/heritrix3/heritrix3-extensions/src/main/java/dk/netarkivet/harvester/harvesting/ExtendedDNSFetcher.java
+++ b/harvester/heritrix3/heritrix3-extensions/src/main/java/dk/netarkivet/harvester/harvesting/ExtendedDNSFetcher.java
@@ -16,7 +16,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.modules.CrawlURI;
 import org.archive.modules.Processor;
 import org.archive.modules.net.CrawlHost;

--- a/harvester/heritrix3/heritrix3-extensions/src/main/java/dk/netarkivet/harvester/harvesting/NASFetchDNS.java
+++ b/harvester/heritrix3/heritrix3-extensions/src/main/java/dk/netarkivet/harvester/harvesting/NASFetchDNS.java
@@ -35,7 +35,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.io.IOUtils;
 import org.archive.io.ReadSource;
 import org.archive.modules.CrawlURI;

--- a/harvester/heritrix3/heritrix3-extensions/src/main/java/dk/netarkivet/harvester/harvesting/OnNSDomainsDecideRule.java
+++ b/harvester/heritrix3/heritrix3-extensions/src/main/java/dk/netarkivet/harvester/harvesting/OnNSDomainsDecideRule.java
@@ -27,7 +27,7 @@ package dk.netarkivet.harvester.harvesting;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.modules.CrawlURI;
 import org.archive.modules.deciderules.surt.SurtPrefixedDecideRule;
 import org.archive.net.UURI;

--- a/harvester/heritrix3/heritrix3-extensions/src/main/java/dk/netarkivet/harvester/harvesting/extractor/ExtractorOAI.java
+++ b/harvester/heritrix3/heritrix3-extensions/src/main/java/dk/netarkivet/harvester/harvesting/extractor/ExtractorOAI.java
@@ -28,7 +28,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.regex.Matcher;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.archive.io.ReplayCharSequence;

--- a/harvester/heritrix3/heritrix3-extensions/src/main/java/dk/netarkivet/harvester/harvesting/extractor/IcelandicExtractorJS.java
+++ b/harvester/heritrix3/heritrix3-extensions/src/main/java/dk/netarkivet/harvester/harvesting/extractor/IcelandicExtractorJS.java
@@ -29,7 +29,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.exception.NestableRuntimeException;
 import org.archive.io.ReplayCharSequence;

--- a/harvester/heritrix3/heritrix3-extensions/src/test/java/dk/netarkivet/harvester/harvesting/DomainnameQueueAssignmentPolicyTester.java
+++ b/harvester/heritrix3/heritrix3-extensions/src/test/java/dk/netarkivet/harvester/harvesting/DomainnameQueueAssignmentPolicyTester.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.net.UURI;
 import org.archive.net.UURIFactory;
 import org.junit.Test;

--- a/harvester/heritrix3/heritrix3-extensions/src/test/java/dk/netarkivet/harvester/harvesting/FixedUURI.java
+++ b/harvester/heritrix3/heritrix3-extensions/src/test/java/dk/netarkivet/harvester/harvesting/FixedUURI.java
@@ -23,7 +23,7 @@
 
 package dk.netarkivet.harvester.harvesting;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.net.UURI;
 
 /**

--- a/harvester/heritrix3/heritrix3-extensions/src/test/java/dk/netarkivet/harvester/harvesting/NASSurtPrefixedDecideRuleTester.java
+++ b/harvester/heritrix3/heritrix3-extensions/src/test/java/dk/netarkivet/harvester/harvesting/NASSurtPrefixedDecideRuleTester.java
@@ -27,7 +27,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.modules.CrawlURI;
 import org.archive.modules.SchedulingConstants;
 import org.archive.modules.deciderules.surt.SurtPrefixedDecideRule;

--- a/harvester/heritrix3/heritrix3-extensions/src/test/java/dk/netarkivet/harvester/harvesting/TestInfo.java
+++ b/harvester/heritrix3/heritrix3-extensions/src/test/java/dk/netarkivet/harvester/harvesting/TestInfo.java
@@ -43,7 +43,7 @@ public class TestInfo {
 
     public static final File ONE_LEVEL_ORDER_FILE = new File(TEMPLATES_DIR, "OneLevel-order.xml");
 
-    static final File ORIGINALS_DIR = new File(BASEDIR, "originals");
+    public static final File ORIGINALS_DIR = new File(BASEDIR, "originals");
 
     static final File WORKING_DIR = new File(BASEDIR, "working");
     static final File CRAWLDIR_ORIGINALS_DIR = new File(BASEDIR, "crawldir");

--- a/harvester/heritrix3/heritrix3-extensions/src/test/java/dk/netarkivet/harvester/harvesting/extractor/ExtractorOAITest.java
+++ b/harvester/heritrix3/heritrix3-extensions/src/test/java/dk/netarkivet/harvester/harvesting/extractor/ExtractorOAITest.java
@@ -30,7 +30,7 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.util.Collection;
 
-import org.apache.commons.httpclient.URIException;
+import org.archive.url.URIException;
 import org.archive.io.ReplayCharSequence;
 import org.archive.modules.CrawlURI;
 import org.archive.modules.extractor.Extractor;
@@ -119,7 +119,6 @@ public class ExtractorOAITest {
             @Override
             public Recorder getRecorder() {
                 return new Recorder(new File("/"), "") {
-                    @Override
                     public ReplayCharSequence getReplayCharSequence() throws IOException {
                         return new TestReplayCharSequence(xmlText);
                     }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.netarchivesuite</groupId>
   <artifactId>netarchivesuite</artifactId>
-  <version>7.8-SNAPSHOT</version>
+  <version>7.7</version>
   <packaging>pom</packaging>
 
   <name>NetarchiveSuite</name>
@@ -17,10 +17,10 @@
     <maven.compiler.release>8</maven.compiler.release>
     <slf4j.version>1.7.25</slf4j.version>
     <logback.version>${logback-core.version}</logback.version>
-    <webarchive-commons.version>1.1.8</webarchive-commons.version>
+    <webarchive-commons.version>2.0.1</webarchive-commons.version>
     <!-- Heritrix versions are from https://github.com/netarchivesuite/heritrix3 which tracks the official
      repository at https://github.com/internetarchive/heritrix3 as closely as we can -->
-    <heritrix3.version>3.7.0-NAS-7.7</heritrix3.version>
+    <heritrix3.version>3.10.0-NAS-7.8-SNAPSHOT</heritrix3.version>
     <heritrix3-wrapper.version>1.0.7</heritrix3-wrapper.version>
     <wayback.version>1.8.0-20130411</wayback.version>
     <openwayback.version>2.0.0</openwayback.version>
@@ -152,7 +152,7 @@
     <url>https://github.com/netarchivesuite/netarchivesuite</url>
     <connection>scm:git:https://github.com/netarchivesuite/netarchivesuite.git</connection>
     <developerConnection>scm:git:git@github.com:netarchivesuite/netarchivesuite.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>netarchivesuite-7.7</tag>
   </scm>
 
   <distributionManagement>
@@ -912,7 +912,7 @@
             <dependency>
               <groupId>org.netarchivesuite</groupId>
               <artifactId>build-tools</artifactId>
-              <version>7.8-SNAPSHOT</version>
+              <version>7.7</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
- Updated heritrix to version 3.10.0-NAS-7.8-SNAPSHOT
- Updated webarchive-commons to 2.0.1 and adapt code (replace `org.apache.commons.httpclient.URIException` with 	`org.archive.url.URIException`
- Adaptation of the code for `dk.netarkivet.common.utils.arc.ARCUtils` and `dk.netarkivet.common.utils.arc.ExtractCDXFromWarcJob` (replace the `ARCRecordMetaData` and `WARCRecord` constants).
