### PR TITLE
Petsva crawl loop interrupt handling

### DIFF
--- a/harvester/harvester-core/src/main/java/dk/netarkivet/harvester/datamodel/PartialHarvest.java
+++ b/harvester/harvester-core/src/main/java/dk/netarkivet/harvester/datamodel/PartialHarvest.java
@@ -209,7 +209,7 @@ public class PartialHarvest extends HarvestDefinition {
                 		+ e.getDescription() + " . Please correct the expression.");
             }
         }
-        if (errMsgs.isEmpty()) {
+        if (!errMsgs.isEmpty()) {
             if (strictMode){ 
                 throw new ArgumentNotValid(errMsgs.size() +  " errors were found: " + StringUtils.join(errMsgs, ","));
             } else {

--- a/harvester/heritrix3/heritrix3-controller/src/main/java/dk/netarkivet/harvester/heritrix3/controller/HeritrixController.java
+++ b/harvester/heritrix3/heritrix3-controller/src/main/java/dk/netarkivet/harvester/heritrix3/controller/HeritrixController.java
@@ -435,11 +435,16 @@ public class HeritrixController extends AbstractRestHeritrixController {
                 progressStatisticsLegend);
         cpm.setHostUrl(getHeritrixJobConsoleURL());
         JobResult jobResult = h3wrapper.job(jobName);
-        if (jobResult != null) {
-            getCrawlServiceAttributes(cpm, jobResult);
-        } else {
-            log.warn("Unable to get Heritrix3 status for job '{}'", jobName);
+        if (jobResult == null || jobResult.status != ResultStatus.OK) {
+            String errMsg =
+                "Problem when sending job request to Heritrix, " +
+                (jobResult == null
+                    ? "jobResult == null"
+                    : "resultstate = " + jobResult.status);
+                log.warn(errMsg);
+                throw new IOFailure(errMsg);
         }
+        getCrawlServiceAttributes(cpm, jobResult);
         if (cpm.crawlIsFinished()) {
             cpm.setStatus(CrawlStatus.CRAWLING_FINISHED);
             // No need to go further, CrawlService.Job bean does not exist

--- a/harvester/heritrix3/heritrix3-controller/src/main/java/dk/netarkivet/harvester/heritrix3/controller/HeritrixController.java
+++ b/harvester/heritrix3/heritrix3-controller/src/main/java/dk/netarkivet/harvester/heritrix3/controller/HeritrixController.java
@@ -612,8 +612,16 @@ public class HeritrixController extends AbstractRestHeritrixController {
         postRequest.addHeader("Accept", "application/xml");
         postRequest.setEntity(postEntity);
         ScriptResult result = h3wrapper.scriptResult(postRequest);
-        return FullFrontierReport.parseContentsAsXML(jobName, result.response,
-                dk.netarkivet.harvester.heritrix3.Constants.XML_RAWOUT_TAG);
+        if (result != null && result.status == ResultStatus.OK) {
+            return FullFrontierReport.parseContentsAsXML(jobName, result.response,
+                   dk.netarkivet.harvester.heritrix3.Constants.XML_RAWOUT_TAG);
+        }
+        LOG.error("Could not get full frontier report from Heritrix, " +
+            (result == null
+                ? "result == null"
+                : "resultstate = " + result.status)
+                 );
+        return new FullFrontierReport(jobName);
     }
 
     @Override

--- a/harvester/heritrix3/heritrix3-controller/src/main/java/dk/netarkivet/harvester/heritrix3/controller/HeritrixLauncher.java
+++ b/harvester/heritrix3/heritrix3-controller/src/main/java/dk/netarkivet/harvester/heritrix3/controller/HeritrixLauncher.java
@@ -185,7 +185,7 @@ public class HeritrixLauncher extends HeritrixLauncherAbstract {
      * <p>
      */
 
-    enum CcOutcome {
+    private enum CcOutcome {
         OK,          // crawl pågår normalt
         CRAWL_OVER,  // crawl är färdig (inte fel)
         FAILED       // tillfälligt fel (IO/HTTP), kan retryas

--- a/harvester/heritrix3/heritrix3-controller/src/main/java/dk/netarkivet/harvester/heritrix3/controller/HeritrixLauncher.java
+++ b/harvester/heritrix3/heritrix3-controller/src/main/java/dk/netarkivet/harvester/heritrix3/controller/HeritrixLauncher.java
@@ -172,18 +172,18 @@ public class HeritrixLauncher extends HeritrixLauncherAbstract {
     private class CrawlControl implements Runnable {
        
         @Override
-        public void run() {
+        public boolean void run() { // Returns if the run was OK
             CrawlProgressMessage cpm = null;
             try {
                 cpm = heritrixController.getCrawlProgress();
             } catch (IOFailure e) {
                 // Log a warning and retry
                 log.warn("IOFailure while getting crawl progress", e);
-                return;
+                return false;
             } catch (HarvestingAbort e) {
                 log.warn("Got HarvestingAbort exception while getting crawl progress. Means crawl is over", e);
                 crawlIsOver = true;
-                return;
+                return false;
             }
             JMSConnectionFactory.getInstance().send(cpm);
 
@@ -191,12 +191,13 @@ public class HeritrixLauncher extends HeritrixLauncherAbstract {
             if (cpm.crawlIsFinished()) {
                 log.info("Job ID {}: crawl is finished.", files.getJobID());
                 crawlIsOver = true;
-                return;
+                return true;
             }
             
             log.info("Job ID: " + files.getJobID() + ", Harvest ID: " + files.getHarvestID() + ", " + cpm.getHostUrl()
                     + "\n" + cpm.getProgressStatisticsLegend() + "\n" + cpm.getJobStatus().getStatus() + " "
                     + cpm.getJobStatus().getProgressStatistics());
+            return true;
         }
 
     }


### PR DESCRIPTION
Handle Heritrix communication problems in the crawl loop
Three statuses after HTTP request to Hertrix:

OK: continue as before – make a frontierreport etc
CRAWL_OVER: break the loop
FAILED: problem, perhaps temporary, with the communication

In the latter case, don’t make a frontierreport, loop with increasing sleep each turn and give up after N retries or Y minutes. And when it gives up it throws IOFailure, which is caught higher úp, making the harvest get the status FAILED instead of DONE.
