### PR TITLE
Upgrade dom4j from 1.6.1 to 2.1.4 (non-vulnerable version)

### DIFF
--- a/common/common-core/pom.xml
+++ b/common/common-core/pom.xml
@@ -195,7 +195,7 @@
       <artifactId>ecj</artifactId>
     </dependency>
     <dependency>
-      <groupId>dom4j</groupId>
+      <groupId>org.dom4j</groupId>
       <artifactId>dom4j</artifactId>
       <exclusions>
         <exclusion>

--- a/common/netarchivesuite-test-utils/pom.xml
+++ b/common/netarchivesuite-test-utils/pom.xml
@@ -13,7 +13,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>dom4j</groupId>
+      <groupId>org.dom4j</groupId>
       <artifactId>dom4j</artifactId>
       <exclusions>
         <exclusion>

--- a/harvester/harvester-core/src/main/java/dk/netarkivet/harvester/datamodel/H1HeritrixTemplate.java
+++ b/harvester/harvester-core/src/main/java/dk/netarkivet/harvester/datamodel/H1HeritrixTemplate.java
@@ -363,7 +363,7 @@ public class H1HeritrixTemplate extends HeritrixTemplate implements Serializable
         // If an acceptiIfPrerequisite node exists, detach and insert before it
         Node acceptIfPrerequisiteNode = orderXMLdoc.selectSingleNode(DECIDERULES_ACCEPT_IF_PREREQUISITE_XPATH);
         if (acceptIfPrerequisiteNode != null) {
-            List<Node> elements = rulesMap.elements();
+            List<Element> elements = rulesMap.elements();
             int insertPosition = elements.indexOf(acceptIfPrerequisiteNode);
             decideRule.detach();
             elements.add(insertPosition, decideRule);
@@ -733,7 +733,7 @@ public class H1HeritrixTemplate extends HeritrixTemplate implements Serializable
         Node acceptIfPrerequisiteNode = template
                 .selectSingleNode(DECIDERULES_ACCEPT_IF_PREREQUISITE_XPATH);
         if (acceptIfPrerequisiteNode != null) {
-            List<Node> elements = rulesMap.elements();
+            List<Element> elements = rulesMap.elements();
             int insertPosition = elements.indexOf(acceptIfPrerequisiteNode);
             decideRule.detach();
             elements.add(insertPosition, decideRule);

--- a/harvester/heritrix3/heritrix3-extensions/pom.xml
+++ b/harvester/heritrix3/heritrix3-extensions/pom.xml
@@ -125,7 +125,7 @@
     </dependency>
 
     <dependency>
-      <groupId>dom4j</groupId>
+      <groupId>org.dom4j</groupId>
       <artifactId>dom4j</artifactId>
       <scope>test</scope>
       <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -789,7 +789,7 @@
         <version>${ecj.version}</version>
       </dependency>
       <dependency>
-        <groupId>dom4j</groupId>
+        <groupId>org.dom4j</groupId>
         <artifactId>dom4j</artifactId>
         <version>${dom4j.version}</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <jetty.version>6.1.26</jetty.version>
     <jsp-2.1-glassfish.version>2.1.v20091210</jsp-2.1-glassfish.version>
     <ecj.version>4.4.2</ecj.version>
-    <dom4j.version>1.6.1</dom4j.version>
+    <dom4j.version>2.1.4</dom4j.version>
     <jetty-servlet-api.version>2.5-20081211</jetty-servlet-api.version>
     <commons-fileupload.version>1.3.3</commons-fileupload.version>
     <jms.version>4.4.1</jms.version>


### PR DESCRIPTION
**Summary**
Upgrades dom4j from 1.6.1 to 2.1.4 to remediate CVE-2018-1000632 (XML injection vulnerability) affecting versions [,2.1.1). The dom4j 2.x line also changed its Maven groupId from dom4j to org.dom4j, so all dependency coordinates were updated accordingly.

**What changed**
Maven dependency updates (5 files):

**File	Line	Change**
pom.xml	40	Version 1.6.1 → 2.1.4
pom.xml	792	groupId dom4j → org.dom4j
pom.xml
198	groupId dom4j → org.dom4j
pom.xml
16	groupId dom4j → org.dom4j
pom.xml
128	groupId dom4j → org.dom4j
Source code fix (1 file):

**File	Lines	Change**
H1HeritrixTemplate.java
366, 736	List<Node> → List<Element>
The source fix addresses a generics change in dom4j 2.x where Element.elements() now returns List<Element> instead of a raw List. No functional behavior change — Element extends Node.

**Verification**
Full reactor compile (mvn compile) passes with BUILD SUCCESS across all 34 modules.
No new compilation errors or warnings introduced.