### PR TITLE
add disabling of auto-refresh by setting interval to zero or below

### DIFF
--- a/common/common-core/src/main/java/dk/netarkivet/common/webinterface/HTMLUtils.java
+++ b/common/common-core/src/main/java/dk/netarkivet/common/webinterface/HTMLUtils.java
@@ -174,15 +174,19 @@ public class HTMLUtils {
      * specify it, use the overloaded method.
      *
      * @param context The context of the web page request.
-     * @param refreshInSeconds auto-refresh time in seconds
+     * @param refreshInSeconds auto-refresh time in seconds (zero or negative values disable refresh)
      * @throws IOException if an error occurs during writing of output.
      */
     public static void generateHeader(PageContext context, long refreshInSeconds) throws IOException {
         ArgumentNotValid.checkNotNull(context, "context");
         String url = ((HttpServletRequest) context.getRequest()).getRequestURL().toString();
         Locale locale = context.getResponse().getLocale();
-        String title = getTitle((HttpServletRequest)context.getRequest(), url, locale);
-        generateHeader(title, refreshInSeconds, context);
+        String title = getTitle((HttpServletRequest) context.getRequest(), url, locale);
+        if (refreshInSeconds > 0) {
+            generateHeader(title, refreshInSeconds, context);
+        } else {
+            generateHeader(title, context);
+        }
     }
 
     /**
@@ -232,7 +236,7 @@ public class HTMLUtils {
      *
      * @param title An internationalised title of the page.
      * @param context The context of the web page request.
-     * @param refreshInSeconds auto-refresh time in seconds
+     * @param refreshInSeconds auto-refresh time in seconds (zero or negative values disable refresh)
      * @throws IOException if an error occurs during writing to output.
      */
     public static void generateHeader(String title, long refreshInSeconds, PageContext context) throws IOException {


### PR DESCRIPTION
Add the capability to disable automatic browser refresh of the monitor pages. 
Simply set the refresh interval in settings.xml to 0 or a negative number (-1 is the traditional way to do it).